### PR TITLE
Add support for showing current GitHub issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ file(GLOB RPM_FILES rpm/*)
 add_custom_target(distfiles SOURCES
   qml/sailfishos-chum-gui.qml
   qml/cover/CoverPage.qml
+  qml/pages/IssuePage.qml
   qml/pages/IssuesListPage.qml
   qml/pages/MainPage.qml
   qml/pages/PackagePage.qml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ file(GLOB RPM_FILES rpm/*)
 add_custom_target(distfiles SOURCES
   qml/sailfishos-chum-gui.qml
   qml/cover/CoverPage.qml
+  qml/pages/IssuesListPage.qml
   qml/pages/MainPage.qml
   qml/pages/PackagePage.qml
   qml/pages/PackagesListPage.qml

--- a/qml/components/ImageLabel.qml
+++ b/qml/components/ImageLabel.qml
@@ -6,8 +6,10 @@ Item {
     height: Math.max(imageUi.implicitHeight, labelUi.implicitHeight)
     width: childrenRect.width
 
+    property alias textColor: labelUi.color
     property alias image: imageUi.source
     property alias label: labelUi.text
+    property alias fontSize: labelUi.font.pixelSize
 
     Image {
         id: imageUi

--- a/qml/pages/IssuePage.qml
+++ b/qml/pages/IssuePage.qml
@@ -35,7 +35,7 @@ Page {
             }
 
             Item {
-                height: Theme.paddingLarge
+                height: Theme.paddingMedium
                 width: parent.width
             }
 

--- a/qml/pages/IssuePage.qml
+++ b/qml/pages/IssuePage.qml
@@ -1,0 +1,159 @@
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import org.chum 1.0
+import "../components"
+
+Page {
+    property ChumPackage pkg
+    property LoadableObject issue
+
+    property ListModel _model: ListModel {}
+    property int commentsCount: issue.value.commentsCount ? issue.value.commentsCount : 0
+    property string number: issue.value.number ? issue.value.number : ""
+    property string title: issue.value.title ? issue.value.title : ""
+
+    id: page
+    allowedOrientations: Orientation.All
+
+    BusyIndicator {
+        id: busyInd
+        anchors.centerIn: parent
+        running: !issue.ready
+        size: BusyIndicatorSize.Large
+    }
+
+    SilicaListView {
+        anchors.fill: parent
+
+        header: Column {
+            width: page.width
+
+            PageHeader {
+                title: pkg.name
+                //% "Issue"
+                description: qsTrId("chum-issue")
+            }
+
+            Item {
+                height: Theme.paddingLarge
+                width: parent.width
+            }
+
+            Label {
+                anchors {
+                    left: parent.left
+                    leftMargin: Theme.horizontalPageMargin
+                    right: parent.right
+                    rightMargin: Theme.horizontalPageMargin
+                }
+                color: Theme.highlightColor
+                font.pixelSize: Theme.fontSizeLarge
+                text: page.title
+                visible: issue.ready
+                wrapMode: Text.WordWrap
+            }
+
+            Item {
+                height: Theme.paddingSmall
+                width: parent.width
+            }
+
+            Label {
+                anchors {
+                    left: parent.left
+                    leftMargin: Theme.horizontalPageMargin
+                    right: parent.right
+                    rightMargin: Theme.horizontalPageMargin
+                }
+                color: Theme.secondaryHighlightColor
+                font.pixelSize: Theme.fontSizeSmall
+                horizontalAlignment: Text.AlignRight
+                //% "Comments: %1"
+                text: qsTrId("chum-issues-comments-number").arg(page.commentsCount)
+                visible: issue.ready
+                wrapMode: Text.WordWrap
+            }
+
+            Item {
+                height: Theme.paddingLarge
+                width: parent.width
+            }
+        }
+
+        model: _model
+        delegate: Item {
+            id: litem
+            height: content.height + Theme.paddingLarge
+            width: page.width
+
+            Column {
+                id: content
+                anchors.verticalCenter: parent.verticalCenter
+                spacing: Theme.paddingSmall
+                width: parent.width
+
+                Label {
+                    anchors {
+                        left: parent.left
+                        leftMargin: Theme.horizontalPageMargin
+                        right: parent.right
+                        rightMargin: Theme.horizontalPageMargin
+                    }
+                    text: model.author
+                    wrapMode: Text.WordWrap
+                    color: Theme.highlightColor
+                }
+
+                Label {
+                    anchors {
+                        left: parent.left
+                        leftMargin: Theme.horizontalPageMargin
+                        right: parent.right
+                        rightMargin: Theme.horizontalPageMargin
+                    }
+                    font.pixelSize: Theme.fontSizeExtraSmall
+                    text: {
+                        if (model.created === model.updated)
+                            return model.created;
+                        //% "Created: %1; Updated: %2"
+                        return qsTrId("chum-created-updated-datetime").
+                               arg(model.created).arg(model.updated);
+                    }
+                    truncationMode: TruncationMode.Fade
+                    color: Theme.secondaryHighlightColor
+                }
+
+                Label {
+                    anchors {
+                        left: parent.left
+                        leftMargin: Theme.horizontalPageMargin
+                        right: parent.right
+                        rightMargin: Theme.horizontalPageMargin
+                    }
+                    color: Theme.primaryColor
+                    text: model.body
+                    textFormat: Text.RichText
+                    wrapMode: Text.WordWrap
+                    onLinkActivated: Qt.openUrlExternally(link)
+                }
+            }
+        }
+
+
+    }
+
+    Connections {
+        target: issue
+        onValueChanged: update()
+    }
+
+    Component.onCompleted: update()
+
+    function update() {
+        _model.clear();
+        if (issue.value && issue.value["discussion"])
+            issue.value["discussion"].forEach(function (e) {
+                _model.append(e);
+            });
+    }
+}

--- a/qml/pages/IssuesListPage.qml
+++ b/qml/pages/IssuesListPage.qml
@@ -1,0 +1,133 @@
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import org.chum 1.0
+import "../components"
+
+Page {
+    property ChumPackage pkg
+    property LoadableObject issues
+
+    property ListModel _model: ListModel {}
+
+    id: page
+    allowedOrientations: Orientation.All
+
+    BusyIndicator {
+        id: busyInd
+        anchors.centerIn: parent
+        running: !issues.ready
+        size: BusyIndicatorSize.Large
+    }
+
+    SilicaListView {
+        anchors.fill: parent
+
+        header: PageHeader {
+            title: pkg.name
+            //% "Issues"
+            description: qsTrId("chum-issues")
+        }
+
+        model: _model
+        delegate: ListItem {
+            id: litem
+            contentHeight: content.height + Theme.paddingLarge
+
+            onClicked: pageStack.push(Qt.resolvedUrl("../pages/IssuePage.qml"), {
+                                          pkg: pkg,
+                                          issue: pkg.issue(model.id)
+                                      })
+
+            Column {
+                id: content
+                anchors.verticalCenter: parent.verticalCenter
+                spacing: Theme.paddingSmall
+                width: parent.width
+
+                Label {
+                    anchors {
+                        left: parent.left
+                        leftMargin: Theme.horizontalPageMargin
+                        right: parent.right
+                        rightMargin: Theme.horizontalPageMargin
+                    }
+                    text: model.title
+                    wrapMode: Text.WordWrap
+                    color: litem.highlighted ? Theme.highlightColor : Theme.primaryColor
+                }
+
+                Item {
+                    anchors {
+                        left: parent.left
+                        leftMargin: Theme.horizontalPageMargin
+                        right: parent.right
+                        rightMargin: Theme.horizontalPageMargin
+                    }
+                    height: Math.max(authLab.implicitHeight, countImL.implicitHeight)
+
+                    Label {
+                        id: authLab
+                        anchors {
+                            left: parent.left
+                            right: countImL.visible ? countImL.left : parent.right
+                            rightMargin: countImL.visible ? Theme.paddingLarge : 0
+                            verticalCenter: parent.verticalCenter
+                        }
+                        font.pixelSize: Theme.fontSizeSmall
+                        //% "#%1 by %2"
+                        text: qsTrId("chum-issue-nr-by").arg(model.number).arg(model.author)
+                        truncationMode: TruncationMode.Fade
+                        color: litem.highlighted ? Theme.secondaryHighlightColor : Theme.secondaryColor
+                    }
+
+                    ImageLabel {
+                        id: countImL
+                        anchors.right: parent.right
+                        anchors.verticalCenter: parent.verticalCenter
+                        image: "image://theme/icon-s-chat"
+                        label: model.commentsCount
+                        textColor: litem.highlighted ? Theme.secondaryHighlightColor : Theme.secondaryColor
+                        visible: model.commentsCount > 0
+                    }
+                }
+
+
+                Label {
+                    anchors {
+                        left: parent.left
+                        leftMargin: Theme.horizontalPageMargin
+                        right: parent.right
+                        rightMargin: Theme.horizontalPageMargin
+                    }
+                    font.pixelSize: Theme.fontSizeExtraSmall
+                    text: {
+                        if (model.created === model.updated)
+                            return model.created;
+                        //% "Created: %1; Updated: %2"
+                        return qsTrId("chum-created-updated-datetime").
+                               arg(model.created).arg(model.updated);
+                    }
+                    truncationMode: TruncationMode.Fade
+                    color: litem.highlighted ? Theme.secondaryHighlightColor : Theme.secondaryColor
+                }
+            }
+        }
+
+
+    }
+
+    Connections {
+        target: issues
+        onValueChanged: update()
+    }
+
+    Component.onCompleted: update()
+
+    function update() {
+        _model.clear();
+        if (issues.value && issues.value["issues"])
+            issues.value["issues"].forEach(function (e) {
+                _model.append(e);
+            });
+    }
+}

--- a/qml/pages/PackagePage.qml
+++ b/qml/pages/PackagePage.qml
@@ -166,7 +166,10 @@ Page {
           visible: pkg.issuesCount > 0
           //% "Issues (%1)"
           text: qsTrId("chum-issues-number").arg(pkg.issuesCount)
-          onClicked: console.log("Issues list page")
+          onClicked: pageStack.push(Qt.resolvedUrl("../pages/IssuesListPage.qml"), {
+                                        pkg: pkg,
+                                        issues: pkg.issues()
+                                    })
         }
       }
 

--- a/qml/pages/ReleasePage.qml
+++ b/qml/pages/ReleasePage.qml
@@ -27,14 +27,37 @@ Page {
 
         Column {
             id: content
-            spacing: Theme.paddingLarge
             visible: release.ready
             width: parent.width
 
             PageHeader {
                 title: pkg.name
-                //% "Release %1"
-                description: qsTrId("chum-release").arg(releaseName)
+                //% "Release"
+                description: qsTrId("chum-release")
+            }
+
+            Item {
+                height: Theme.paddingMedium
+                width: parent.width
+            }
+
+            Label {
+                anchors {
+                    left: parent.left
+                    leftMargin: Theme.horizontalPageMargin
+                    right: parent.right
+                    rightMargin: Theme.horizontalPageMargin
+                }
+                color: Theme.highlightColor
+                font.pixelSize: Theme.fontSizeLarge
+                text: releaseName
+                visible: release.ready
+                wrapMode: Text.WordWrap
+            }
+
+            Item {
+                height: Theme.paddingSmall
+                width: parent.width
             }
 
             Label {
@@ -50,6 +73,11 @@ Page {
                 text: releaseDate
             }
 
+            Item {
+                height: Theme.paddingLarge
+                width: parent.width
+            }
+
             Label {
                 anchors {
                     left: parent.left
@@ -57,7 +85,7 @@ Page {
                     right: parent.right
                     rightMargin: Theme.horizontalPageMargin
                 }
-                color: Theme.highlightColor
+                color: Theme.primaryColor
                 text: releaseDescription
                 textFormat: Text.RichText
                 wrapMode: Text.WordWrap

--- a/src/chumpackage.cpp
+++ b/src/chumpackage.cpp
@@ -44,6 +44,15 @@ bool ChumPackage::installed() const {
   return !m_installed_version.isEmpty();
 }
 
+LoadableObject* ChumPackage::issues() {
+  if (m_issues.ready()) return &m_issues;
+  if (m_project != nullptr)
+    m_project->issues(&m_issues);
+  else
+    m_issues.setEmpty();
+  return &m_issues;
+}
+
 LoadableObject* ChumPackage::release(const QString &id) {
   if (m_project != nullptr)
     m_project->release(id, &m_release_info);

--- a/src/chumpackage.cpp
+++ b/src/chumpackage.cpp
@@ -23,13 +23,16 @@ using namespace PackageKit;
 ChumPackage::ChumPackage(QObject *parent)
   : QObject{parent}
 {
-  // not used, added for compatibility
+  m_issues = new LoadableObject(this);
+  m_release_info = new LoadableObject(this);
+  m_releases = new LoadableObject(this);
 }
 
 
-ChumPackage::ChumPackage(QString id, QObject *parent)
-  : QObject{parent}, m_id(id)
+ChumPackage::ChumPackage(const QString &id, QObject *parent)
+  : ChumPackage(parent)
 {
+  m_id = id;
 }
 
 QString ChumPackage::developer() const {
@@ -45,29 +48,29 @@ bool ChumPackage::installed() const {
 }
 
 LoadableObject* ChumPackage::issues() {
-  if (m_issues.ready()) return &m_issues;
+  if (m_issues->ready()) return m_issues;
   if (m_project != nullptr)
-    m_project->issues(&m_issues);
+    m_project->issues(m_issues);
   else
-    m_issues.setEmpty();
-  return &m_issues;
+    m_issues->setEmpty();
+  return m_issues;
 }
 
 LoadableObject* ChumPackage::release(const QString &id) {
   if (m_project != nullptr)
-    m_project->release(id, &m_release_info);
+    m_project->release(id, m_release_info);
   else
-    m_release_info.setEmpty();
-  return &m_release_info;
+    m_release_info->setEmpty();
+  return m_release_info;
 }
 
 LoadableObject* ChumPackage::releases() {
-  if (m_releases.ready()) return &m_releases;
+  if (m_releases->ready()) return m_releases;
   if (m_project != nullptr)
-    m_project->releases(&m_releases);
+    m_project->releases(m_releases);
   else
-    m_releases.setEmpty();
-  return &m_releases;
+    m_releases->setEmpty();
+  return m_releases;
 }
 
 void ChumPackage::setPkid(const QString &pkid) {

--- a/src/chumpackage.cpp
+++ b/src/chumpackage.cpp
@@ -23,6 +23,7 @@ using namespace PackageKit;
 ChumPackage::ChumPackage(QObject *parent)
   : QObject{parent}
 {
+  m_issue_info = new LoadableObject(this);
   m_issues = new LoadableObject(this);
   m_release_info = new LoadableObject(this);
   m_releases = new LoadableObject(this);
@@ -45,6 +46,14 @@ QString ChumPackage::developer() const {
 
 bool ChumPackage::installed() const {
   return !m_installed_version.isEmpty();
+}
+
+LoadableObject* ChumPackage::issue(const QString &id) {
+  if (m_project != nullptr)
+    m_project->issue(id, m_issue_info);
+  else
+    m_issue_info->setEmpty();
+  return m_issue_info;
 }
 
 LoadableObject* ChumPackage::issues() {

--- a/src/chumpackage.h
+++ b/src/chumpackage.h
@@ -62,6 +62,7 @@ public:
   ChumPackage(QObject *parent = nullptr);
   ChumPackage(const QString &id, QObject *parent = nullptr);
 
+  Q_INVOKABLE LoadableObject* issue(const QString &id);
   Q_INVOKABLE LoadableObject* issues();
   Q_INVOKABLE LoadableObject* release(const QString &id);
   Q_INVOKABLE LoadableObject* releases();
@@ -119,6 +120,7 @@ signals:
 
 private:
   ProjectAbstract *m_project{nullptr};
+  LoadableObject  *m_issue_info{nullptr};
   LoadableObject  *m_issues{nullptr};
   LoadableObject  *m_release_info{nullptr};
   LoadableObject  *m_releases{nullptr};

--- a/src/chumpackage.h
+++ b/src/chumpackage.h
@@ -60,7 +60,7 @@ public:
   };
 
   ChumPackage(QObject *parent = nullptr);
-  ChumPackage(QString id, QObject *parent = nullptr);
+  ChumPackage(const QString &id, QObject *parent = nullptr);
 
   Q_INVOKABLE LoadableObject* issues();
   Q_INVOKABLE LoadableObject* release(const QString &id);
@@ -119,9 +119,9 @@ signals:
 
 private:
   ProjectAbstract *m_project{nullptr};
-  LoadableObject   m_issues;
-  LoadableObject   m_release_info;
-  LoadableObject   m_releases;
+  LoadableObject  *m_issues{nullptr};
+  LoadableObject  *m_release_info{nullptr};
+  LoadableObject  *m_releases{nullptr};
 
   QString     m_id; // ID of the package as used in Chum
   QString     m_pkid; // Package ID as set by PackageKit

--- a/src/chumpackage.h
+++ b/src/chumpackage.h
@@ -62,6 +62,7 @@ public:
   ChumPackage(QObject *parent = nullptr);
   ChumPackage(QString id, QObject *parent = nullptr);
 
+  Q_INVOKABLE LoadableObject* issues();
   Q_INVOKABLE LoadableObject* release(const QString &id);
   Q_INVOKABLE LoadableObject* releases();
 
@@ -118,6 +119,7 @@ signals:
 
 private:
   ProjectAbstract *m_project{nullptr};
+  LoadableObject   m_issues;
   LoadableObject   m_release_info;
   LoadableObject   m_releases;
 

--- a/src/projectabstract.cpp
+++ b/src/projectabstract.cpp
@@ -5,5 +5,4 @@ ProjectAbstract::ProjectAbstract(ChumPackage *package) :
   QObject(package),
   m_package(package)
 {
-
 }

--- a/src/projectabstract.h
+++ b/src/projectabstract.h
@@ -13,6 +13,7 @@ class ProjectAbstract : public QObject
 public:
   explicit ProjectAbstract(ChumPackage *package);
 
+  virtual void issues(LoadableObject *value) = 0;
   virtual void release(const QString &id, LoadableObject *value) = 0;
   virtual void releases(LoadableObject *value) = 0;
 

--- a/src/projectabstract.h
+++ b/src/projectabstract.h
@@ -13,6 +13,7 @@ class ProjectAbstract : public QObject
 public:
   explicit ProjectAbstract(ChumPackage *package);
 
+  virtual void issue(const QString &id, LoadableObject *value) = 0;
   virtual void issues(LoadableObject *value) = 0;
   virtual void release(const QString &id, LoadableObject *value) = 0;
   virtual void releases(LoadableObject *value) = 0;

--- a/src/projectgithub.cpp
+++ b/src/projectgithub.cpp
@@ -18,6 +18,26 @@
 static QString reqAuth{QStringLiteral("bearer " GITHUB_TOKEN)};
 static QString reqUrl{QStringLiteral("https://api.github.com/graphql")};
 
+//////////////////////////////////////////////////////
+/// helper functions
+
+static QString getName(const QVariant &v) {
+  QVariantMap m = v.toMap();
+  QString login = m[QLatin1String("login")].toString();
+  QString name = m[QLatin1String("name")].toString();
+  if (login.isEmpty()) return name;
+  if (name.isEmpty()) return login;
+  return QStringLiteral("%1 (%2)").arg(name, login);
+}
+
+static QNetworkReply* sendQuery(const QString &query) {
+  QNetworkRequest request;
+  request.setUrl(reqUrl);
+  request.setRawHeader("Content-Type", "application/x-www-form-urlencoded");
+  request.setRawHeader("Authorization", reqAuth.toLocal8Bit());
+  return nMng->post(request, query.toLocal8Bit());
+}
+
 static bool parseUrl(const QString &u, QString &org, QString &repo) {
   QUrl url(u);
   QString host = url.host();
@@ -30,6 +50,21 @@ static bool parseUrl(const QString &u, QString &org, QString &repo) {
   repo = path[1];
   return true;
 }
+
+static QString parseDate(QString txt, bool short_format=false) {
+  QDateTime dt = QDateTime::fromString(txt, Qt::ISODate);
+  return QLocale::system().toString(dt.toLocalTime().date(),
+                                    short_format ? QLocale::ShortFormat :
+                                                   QLocale::LongFormat);
+}
+
+//static QString parseDateTime(QString txt) {
+//  QDateTime dt = QDateTime::fromString(txt, Qt::ISODate);
+//  return QLocale::system().toString(dt.toLocalTime(), QLocale::LongFormat);
+//}
+
+//////////////////////////////////////////////////////
+/// ProjectGitHub
 
 ProjectGitHub::ProjectGitHub(const QString &url, ChumPackage *package) : ProjectAbstract(package) {
   bool ok = parseUrl(url, m_org, m_repo);
@@ -55,6 +90,7 @@ bool ProjectGitHub::isProject(const QString &url) {
   QString o, p;
   return parseUrl(url, o, p);
 }
+
 
 void ProjectGitHub::fetchRepoInfo() {
   QString query = QStringLiteral(R"(
@@ -96,11 +132,7 @@ query {
 )").arg(m_org, m_repo);
   query = query.replace('\n', ' ');
 
-  QNetworkRequest request;
-  request.setUrl(reqUrl);
-  request.setRawHeader("Content-Type", "application/x-www-form-urlencoded");
-  request.setRawHeader("Authorization", reqAuth.toLocal8Bit());
-  QNetworkReply *reply = nMng->post(request, query.toLocal8Bit());
+  QNetworkReply *reply = sendQuery(query);
   connect(reply, &QNetworkReply::finished, [this, reply](){
     if (reply->error() != QNetworkReply::NoError) {
       qWarning() << "Failed to fetch repository data for" << this->m_org << this->m_repo;
@@ -143,6 +175,78 @@ query {
   });
 }
 
+
+void ProjectGitHub::issues(LoadableObject *value) {
+  const QString issues_id{QStringLiteral("issues")};
+  value->reset(issues_id);
+
+  QString query = QStringLiteral(R"(
+{
+"query": "
+query {
+  repository(owner: \"%1\", name:\"%2\") {
+    issues(first: 100, states: OPEN, orderBy: {field: UPDATED_AT, direction: DESC}) {
+      nodes {
+        number
+        title
+        author {
+          ... on User {
+            login
+            name
+          }
+          ... on Organization {
+            login
+            name
+          }
+        }
+        createdAt
+        updatedAt
+        comments {
+          totalCount
+        }
+      }
+    }
+  }
+}"
+}
+)").arg(m_org, m_repo);
+  query = query.replace('\n', ' ');
+
+  QNetworkReply *reply = sendQuery(query);
+  connect(reply, &QNetworkReply::finished, [this, issues_id, reply, value](){
+    if (reply->error() != QNetworkReply::NoError) {
+      qWarning() << "Failed to fetch issues for" << this->m_org << this->m_repo;
+      qWarning() << "Error: " << reply->errorString();
+    }
+
+    QByteArray data = reply->readAll();
+    QVariantList r = QJsonDocument::fromJson(data).object().
+          value("data").toObject().value("repository").toObject().
+          value("issues").toObject().value("nodes").toArray().toVariantList();
+
+    QVariantList rlist;
+    for (auto e: r) {
+      QVariantMap element = e.toMap();
+      QVariantMap m;
+      m["id"] = element.value("number");
+      m["author"] = getName(element.value("author"));
+      m["commentsCount"] = element.value("comments").toMap().value("totalCount").toInt();
+      m["number"] = element.value("number");
+      m["title"] = element.value("title");
+      m["created"] = parseDate(element.value("createdAt").toString(), true);
+      m["updated"] = parseDate(element.value("updatedAt").toString(), true);
+      rlist.append(m);
+    }
+
+    QVariantMap result;
+    result["issues"] = rlist;
+    value->setValue(issues_id, result);
+
+    reply->deleteLater();
+  });
+}
+
+
 void ProjectGitHub::release(const QString &release_id, LoadableObject *value) {
   if (value->ready() && value->valueId()==release_id)
     return; // value already corresponds to that release
@@ -165,11 +269,7 @@ query {
 
   query = query.replace('\n', ' ');
 
-  QNetworkRequest request;
-  request.setUrl(reqUrl);
-  request.setRawHeader("Content-Type", "application/x-www-form-urlencoded");
-  request.setRawHeader("Authorization", reqAuth.toLocal8Bit());
-  QNetworkReply *reply = nMng->post(request, query.toLocal8Bit());
+  QNetworkReply *reply = sendQuery(query);
   connect(reply, &QNetworkReply::finished, [this, release_id, reply, value](){
     if (reply->error() != QNetworkReply::NoError) {
       qWarning() << "Failed to fetch release for" << this->m_org << this->m_repo;
@@ -184,14 +284,13 @@ query {
     QVariantMap result;
     result["name"] = r.value("name");
     result["description"] = r.value("descriptionHTML");
-    QDateTime dt = QDateTime::fromString(r.value("createdAt").toString(),
-                                         Qt::ISODate);
-    result["datetime"] = QLocale::system().toString(dt.toLocalTime().date(), QLocale::LongFormat);
+    result["datetime"] = parseDate(r.value("createdAt").toString());
 
     value->setValue(release_id, result);
     reply->deleteLater();
   });
 }
+
 
 void ProjectGitHub::releases(LoadableObject *value) {
   const QString releases_id{QStringLiteral("releases")};
@@ -216,11 +315,7 @@ query {
 )").arg(m_org, m_repo);
   query = query.replace('\n', ' ');
 
-  QNetworkRequest request;
-  request.setUrl(reqUrl);
-  request.setRawHeader("Content-Type", "application/x-www-form-urlencoded");
-  request.setRawHeader("Authorization", reqAuth.toLocal8Bit());
-  QNetworkReply *reply = nMng->post(request, query.toLocal8Bit());
+  QNetworkReply *reply = sendQuery(query);
   connect(reply, &QNetworkReply::finished, [this, releases_id, reply, value](){
     if (reply->error() != QNetworkReply::NoError) {
       qWarning() << "Failed to fetch releases for" << this->m_org << this->m_repo;
@@ -238,9 +333,7 @@ query {
       QVariantMap m;
       m["id"] = element.value("tagName");
       m["name"] = element.value("name");
-      QDateTime dt = QDateTime::fromString(element.value("createdAt").toString(),
-                                           Qt::ISODate);
-      m["datetime"] = QLocale::system().toString(dt.toLocalTime().date(), QLocale::LongFormat);
+      m["datetime"] = parseDate(element.value("createdAt").toString());
       rlist.append(m);
     }
 

--- a/src/projectgithub.h
+++ b/src/projectgithub.h
@@ -14,6 +14,7 @@ public:
 
   static bool isProject(const QString &url);
 
+  virtual void issue(const QString &id, LoadableObject *value) override;
   virtual void issues(LoadableObject *value) override;
   virtual void release(const QString &id, LoadableObject *value) override;
   virtual void releases(LoadableObject *value) override;

--- a/src/projectgithub.h
+++ b/src/projectgithub.h
@@ -14,6 +14,7 @@ public:
 
   static bool isProject(const QString &url);
 
+  virtual void issues(LoadableObject *value) override;
   virtual void release(const QString &id, LoadableObject *value) override;
   virtual void releases(LoadableObject *value) override;
 

--- a/translations/sailfishos-chum-gui.ts
+++ b/translations/sailfishos-chum-gui.ts
@@ -155,6 +155,21 @@
         <source>Release %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="chum-issues">
+        <location filename="../qml/pages/IssuesListPage.qml" line="28"/>
+        <source>Issues</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="chum-issue-nr-by">
+        <location filename="../qml/pages/IssuesListPage.qml" line="78"/>
+        <source>#%1 by %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="chum-created-updated-datetime">
+        <location filename="../qml/pages/IssuesListPage.qml" line="107"/>
+        <source>Created: %1; Updated: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PackagePage</name>
@@ -174,7 +189,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/PackagePage.qml" line="176"/>
+        <location filename="../qml/pages/PackagePage.qml" line="179"/>
         <source>Make Dontation</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/sailfishos-chum-gui.ts
+++ b/translations/sailfishos-chum-gui.ts
@@ -151,8 +151,9 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-release">
-        <location filename="../qml/pages/ReleasePage.qml" line="37"/>
-        <source>Release %1</source>
+        <location filename="../qml/pages/ReleasePage.qml" line="36"/>
+        <source>Release</source>
+        <oldsource>Release %1</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-issues">
@@ -165,7 +166,18 @@
         <source>#%1 by %2</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="chum-issue">
+        <location filename="../qml/pages/IssuePage.qml" line="34"/>
+        <source>Issue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="chum-issues-comments-number">
+        <location filename="../qml/pages/IssuePage.qml" line="72"/>
+        <source>Comments: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="chum-created-updated-datetime">
+        <location filename="../qml/pages/IssuePage.qml" line="119"/>
         <location filename="../qml/pages/IssuesListPage.qml" line="107"/>
         <source>Created: %1; Updated: %2</source>
         <translation type="unfinished"></translation>


### PR DESCRIPTION
This PR adds support for showing a list and information regarding the most recent GitHub issues (limited by 100). In addition, as it made sense to fix it asap, it should fix #18 and is using colors as suggested in #20.

Please review.