### PR TITLE
Enable GitHub support for packages linking to Github repo

### DIFF
--- a/src/chumpackage.cpp
+++ b/src/chumpackage.cpp
@@ -152,8 +152,6 @@ void ChumPackage::setDetails(const PackageKit::Details &v) {
       metainjson = QByteArray::fromStdString(out);
       metainjson = metainjson.replace("~", "\"\"");
 
-      qDebug() << m_pkid << "Meta:" << metainjson;
-
       //remove yaml from list
       descLines.pop_back();
   }
@@ -186,8 +184,11 @@ void ChumPackage::setDetails(const PackageKit::Details &v) {
   m_url_issues = json.value("Url").toObject().value("Bugtracker").toString();
   m_donation = json.value("Url").toObject().value("Donation").toString();
 
-  if (ProjectGitHub::isProject(m_repo_url))
-    m_project = new ProjectGitHub(m_repo_url, this);
+  for (const QString &u: {m_repo_url, m_url}) {
+      if (ProjectGitHub::isProject(u))
+        m_project = new ProjectGitHub(u, this);
+      if (m_project) break;
+  }
 
   emit updated(m_id, PackageRefreshRole);
 }

--- a/src/chumpackage.h
+++ b/src/chumpackage.h
@@ -11,7 +11,6 @@ class ChumPackage : public QObject {
 
   Q_PROPERTY(QString id READ id NOTIFY pkidChanged)
   Q_PROPERTY(QString pkid READ pkid NOTIFY pkidChanged)
-  Q_PROPERTY(bool    updateAvailable READ updateAvailable NOTIFY updated)
 
   Q_PROPERTY(QString    availableVersion READ availableVersion NOTIFY updated)
   Q_PROPERTY(QStringList categories READ categories   NOTIFY updated)
@@ -34,6 +33,7 @@ class ChumPackage : public QObject {
   Q_PROPERTY(int        starsCount  READ starsCount   NOTIFY updated)
   Q_PROPERTY(QString    summary     READ summary      NOTIFY updated)
   Q_PROPERTY(QString    type        READ type         NOTIFY updated)
+  Q_PROPERTY(bool       updateAvailable READ updateAvailable NOTIFY updated)
   Q_PROPERTY(QString    url         READ url          NOTIFY updated)
   Q_PROPERTY(QString    urlForum    READ urlForum     NOTIFY updated)
   Q_PROPERTY(QString    urlIssues   READ urlIssues    NOTIFY updated)
@@ -69,7 +69,6 @@ public:
 
   QString id() const { return m_id; }
   QString pkid() const { return m_pkid; }
-  bool updateAvailable() const { return m_update_available; }
   bool detailsNeedsUpdate() const { return m_details_update; }
   bool installedVersionNeedsUpdate() const { return m_installed_update; }
 
@@ -94,6 +93,7 @@ public:
   int     starsCount() const { return m_stars_count; }
   QString summary() const { return m_summary; }
   QString type() const { return m_type; }
+  bool    updateAvailable() const { return m_update_available; }
   QString url() const { return m_url; }
   QString urlForum() const { return m_url_forum; }
   QString urlIssues() const { return m_url_issues; }

--- a/src/chumpackagesmodel.cpp
+++ b/src/chumpackagesmodel.cpp
@@ -47,6 +47,7 @@ QHash<int, QByteArray> ChumPackagesModel::roleNames() const {
     {ChumPackage::PackageInstalledVersionRole,  QByteArrayLiteral("packageInstalledVersion")},
     {ChumPackage::PackageNameRole,     QByteArrayLiteral("packageName")},
     {ChumPackage::PackageStarsCountRole, QByteArrayLiteral("packageStarsCount")},
+    {ChumPackage::PackageUpdateAvailableRole,  QByteArrayLiteral("packageUpdateAvailable")},
   };
 }
 
@@ -107,7 +108,8 @@ void ChumPackagesModel::updatePackage(QString packageId, ChumPackage::Role role)
     ChumPackage::PackageNameRole,
     ChumPackage::PackageStarsCountRole,
     ChumPackage::PackageInstalledRole,
-    ChumPackage::PackageInstalledVersionRole
+    ChumPackage::PackageInstalledVersionRole,
+    ChumPackage::PackageUpdateAvailableRole
   };
 
   QList<ChumPackage::Role> search_roles{


### PR DESCRIPTION
Many packages have URL specified as a GitHub repo. For these packages, if repository is not given by SPEC metadata section, GitHub link can be still established. In practice, it enables that link to ~90 packages if my count is correct.

In addition, small cleanups in this PR as well as adding `packageUpdateAvailable` property to packages list model. That would be required when we will change package list view.

Please review.