### PR TITLE
Add GitLab support and enable GitHub and GitLab link when possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ project(sailfishos-chum-gui
 
 set(REPO "sailfishos-chum" CACHE STRING "Alias of the repository")
 set(GITHUB_TOKEN "unset" CACHE STRING "GitHub access token for GraphQL queries")
+set(GITLAB_TOKEN "unset" CACHE STRING "GitLab.com access token for GraphQL queries")
 
 include(FindPkgConfig)
 

--- a/qml/pages/IssuePage.qml
+++ b/qml/pages/IssuePage.qml
@@ -30,8 +30,11 @@ Page {
 
             PageHeader {
                 title: pkg.name
-                //% "Issue"
-                description: qsTrId("chum-issue")
+                description: issue.ready ?
+                                 //% "Issue: #%1"
+                                 qsTrId("chum-issue-with-number").arg(number) :
+                                 //% "Issue"
+                                 qsTrId("chum-issue")
             }
 
             Item {

--- a/rpm/sailfishos-chum-gui.spec
+++ b/rpm/sailfishos-chum-gui.spec
@@ -9,6 +9,7 @@ License:        MIT
 URL:            https://github.com/sailfishos-chum/sailfishos-chum-gui
 Source0:        %{name}-%{version}.tar.bz2
 Source1:        token-github.txt
+Source2:        token-gitlab.txt
 Requires:       sailfishsilica-qt5 >= 0.10.9
 %if 0%{?chum_testing_repo}
 Requires:       sailfishos-chum-testing
@@ -35,6 +36,7 @@ A client app for the Chum repositories
 %build
 %cmake -DCHUMGUI_VERSION=%(echo %{version} | grep -Eo '^[0-9]+(\.[0-9]+)*') \
        -DGITHUB_TOKEN=%(cat token-github.txt)  \
+       -DGITLAB_TOKEN=%(cat token-gitlab.txt)  \
 %if 0%{?chum_testing_repo}
        -DREPO=sailfishos-chum-testing \
 %endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,8 @@ add_executable(${PROJECT_NAME}
   projectabstract.h
   projectgithub.cpp
   projectgithub.h
+  projectgitlab.cpp
+  projectgitlab.h
   main.cpp
   main.h
 )
@@ -30,6 +32,10 @@ set_source_files_properties(main.cpp PROPERTIES
 
 set_source_files_properties(projectgithub.cpp PROPERTIES
   COMPILE_DEFINITIONS GITHUB_TOKEN=\"${GITHUB_TOKEN}\"
+)
+
+set_source_files_properties(projectgitlab.cpp PROPERTIES
+  COMPILE_DEFINITIONS GITLAB_TOKEN=\"${GITLAB_TOKEN}\"
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/src/chumpackage.cpp
+++ b/src/chumpackage.cpp
@@ -1,6 +1,7 @@
 #include "chumpackage.h"
 
 #include "projectgithub.h"
+#include "projectgitlab.h"
 
 #include <PackageKit/Daemon>
 #include <PackageKit/Details>
@@ -187,6 +188,8 @@ void ChumPackage::setDetails(const PackageKit::Details &v) {
   for (const QString &u: {m_repo_url, m_url}) {
       if (ProjectGitHub::isProject(u))
         m_project = new ProjectGitHub(u, this);
+      else if (ProjectGitLab::isProject(u))
+        m_project = new ProjectGitLab(u, this);
       if (m_project) break;
   }
 

--- a/src/chumpackage.cpp
+++ b/src/chumpackage.cpp
@@ -152,8 +152,6 @@ void ChumPackage::setDetails(const PackageKit::Details &v) {
       metainjson = QByteArray::fromStdString(out);
       metainjson = metainjson.replace("~", "\"\"");
 
-      qDebug() << m_pkid << "Meta:" << metainjson;
-
       //remove yaml from list
       descLines.pop_back();
   }
@@ -186,8 +184,11 @@ void ChumPackage::setDetails(const PackageKit::Details &v) {
   m_url_issues = json.value("Url").toObject().value("Bugtracker").toString();
   m_donation = json.value("Url").toObject().value("Donation").toString();
 
-  if (ProjectGitHub::isProject(m_repo_url))
-    m_project = new ProjectGitHub(m_repo_url, this);
+  for (const QString &u: {m_repo_url, m_url}) {
+      if (ProjectGitHub::isProject(u))
+        m_project = new ProjectGitHub(u, this);
+      if (m_project) break;
+  }
 
   emit updated(m_id, PackageRefreshRole);
 }

--- a/src/chumpackage.h
+++ b/src/chumpackage.h
@@ -11,7 +11,6 @@ class ChumPackage : public QObject {
 
   Q_PROPERTY(QString id READ id NOTIFY pkidChanged)
   Q_PROPERTY(QString pkid READ pkid NOTIFY pkidChanged)
-  Q_PROPERTY(bool    updateAvailable READ updateAvailable NOTIFY updated)
 
   Q_PROPERTY(QString    availableVersion READ availableVersion NOTIFY updated)
   Q_PROPERTY(QStringList categories READ categories   NOTIFY updated)
@@ -34,6 +33,7 @@ class ChumPackage : public QObject {
   Q_PROPERTY(int        starsCount  READ starsCount   NOTIFY updated)
   Q_PROPERTY(QString    summary     READ summary      NOTIFY updated)
   Q_PROPERTY(QString    type        READ type         NOTIFY updated)
+  Q_PROPERTY(bool       updateAvailable READ updateAvailable NOTIFY updated)
   Q_PROPERTY(QString    url         READ url          NOTIFY updated)
   Q_PROPERTY(QString    urlForum    READ urlForum     NOTIFY updated)
   Q_PROPERTY(QString    urlIssues   READ urlIssues    NOTIFY updated)
@@ -69,7 +69,6 @@ public:
 
   QString id() const { return m_id; }
   QString pkid() const { return m_pkid; }
-  bool updateAvailable() const { return m_update_available; }
   bool detailsNeedsUpdate() const { return m_details_update; }
   bool installedVersionNeedsUpdate() const { return m_installed_update; }
 
@@ -94,6 +93,7 @@ public:
   int     starsCount() const { return m_stars_count; }
   QString summary() const { return m_summary; }
   QString type() const { return m_type; }
+  bool    updateAvailable() const { return m_update_available; }
   QString url() const { return m_url; }
   QString urlForum() const { return m_url_forum; }
   QString urlIssues() const { return m_url_issues; }

--- a/src/chumpackagesmodel.cpp
+++ b/src/chumpackagesmodel.cpp
@@ -47,6 +47,7 @@ QHash<int, QByteArray> ChumPackagesModel::roleNames() const {
     {ChumPackage::PackageInstalledVersionRole,  QByteArrayLiteral("packageInstalledVersion")},
     {ChumPackage::PackageNameRole,     QByteArrayLiteral("packageName")},
     {ChumPackage::PackageStarsCountRole, QByteArrayLiteral("packageStarsCount")},
+    {ChumPackage::PackageUpdateAvailableRole,  QByteArrayLiteral("packageUpdateAvailable")},
   };
 }
 
@@ -107,7 +108,8 @@ void ChumPackagesModel::updatePackage(QString packageId, ChumPackage::Role role)
     ChumPackage::PackageNameRole,
     ChumPackage::PackageStarsCountRole,
     ChumPackage::PackageInstalledRole,
-    ChumPackage::PackageInstalledVersionRole
+    ChumPackage::PackageInstalledVersionRole,
+    ChumPackage::PackageUpdateAvailableRole
   };
 
   QList<ChumPackage::Role> search_roles{

--- a/src/projectgitlab.cpp
+++ b/src/projectgitlab.cpp
@@ -1,0 +1,388 @@
+#include "projectgitlab.h"
+#include "chumpackage.h"
+#include "main.h"
+
+#include <QDebug>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+#include <QLocale>
+#include <QNetworkRequest>
+#include <QNetworkReply>
+#include <QSharedPointer>
+#include <QUrl>
+#include <QVariantList>
+#include <QVariantMap>
+
+static QString reqAuth{QStringLiteral("Bearer " GITLAB_TOKEN)};
+static QString reqUrl{QStringLiteral("https://gitlab.com/api/graphql")};
+
+//////////////////////////////////////////////////////
+/// helper functions
+
+static QString getName(const QVariant &v) {
+  QVariantMap m = v.toMap();
+  QString login = m[QLatin1String("username")].toString();
+  QString name = m[QLatin1String("name")].toString();
+  if (login.isEmpty() || name==login) return name;
+  if (name.isEmpty()) return login;
+  return QStringLiteral("%1 (%2)").arg(name, login);
+}
+
+static QNetworkReply* sendQuery(const QString &query) {
+  QNetworkRequest request;
+  request.setUrl(reqUrl);
+  request.setRawHeader("Content-Type", "application/json");
+  request.setRawHeader("Authorization", reqAuth.toLocal8Bit());
+  return nMng->post(request, query.toLocal8Bit());
+}
+
+static bool parseUrl(const QString &u, QString &path) {
+  QUrl url(u);
+  QString host = url.host();
+  QString p = url.path();
+  if (p.startsWith('/')) p = p.mid(1);
+  if (p.endsWith('/')) p.chop(1);
+
+  if (host != QStringLiteral("gitlab.com"))
+    return false;
+
+  path = p;
+  return true;
+}
+
+static QString parseDate(QString txt, bool short_format=false) {
+  QDateTime dt = QDateTime::fromString(txt, Qt::ISODate);
+  return QLocale::system().toString(dt.toLocalTime().date(),
+                                    short_format ? QLocale::ShortFormat :
+                                                   QLocale::LongFormat);
+}
+
+//static QString parseDateTime(QString txt) {
+//  QDateTime dt = QDateTime::fromString(txt, Qt::ISODate);
+//  return QLocale::system().toString(dt.toLocalTime(), QLocale::LongFormat);
+//}
+
+//////////////////////////////////////////////////////
+/// ProjectGitLab
+
+ProjectGitLab::ProjectGitLab(const QString &url, ChumPackage *package) : ProjectAbstract(package) {
+  bool ok = parseUrl(url, m_path);
+  if (!ok) {
+    qWarning() << "Shouldn't happen: ProjectGitLab initialized with incorrect service" << url;
+    return;
+  }
+
+  qDebug() << "GitLab" << m_path;
+
+  // url is not set as it can be different homepage that is retrieved from query
+  m_package->setUrlIssues(QStringLiteral("https://gitlab.com/%1/-/issues").arg(m_path));
+
+  // fetch information from GitLab
+  fetchRepoInfo();
+}
+
+// static
+bool ProjectGitLab::isProject(const QString &url) {
+  QString p;
+  return parseUrl(url, p);
+}
+
+
+void ProjectGitLab::fetchRepoInfo() {
+  QString query = QStringLiteral(R"(
+{
+"query": "
+query {
+  project(fullPath: \"%1\") {
+    forksCount
+    openIssuesCount
+    mergeRequests(state: opened) {
+      count
+    }
+    releases {
+      count
+    }
+    starCount
+  }
+}"
+}
+)").arg(m_path);
+  query = query.replace('\n', ' ');
+
+  QNetworkReply *reply = sendQuery(query);
+  connect(reply, &QNetworkReply::finished, [this, reply](){
+    if (reply->error() != QNetworkReply::NoError) {
+      qWarning() << "GitLab: Failed to fetch repository data for GitLab" << this->m_path;
+      qWarning() << "GitLab: Error: " << reply->errorString();
+    }
+
+    QByteArray data = reply->readAll();
+    QJsonObject r{QJsonDocument::fromJson(data).object().
+          value("data").toObject().value("project").toObject()};
+
+    int vi;
+
+    vi = r.value("starCount").toInt(-1);
+    if (vi>=0) m_package->setStarsCount(vi);
+
+    vi = r.value("forksCount").toInt(0);
+    if (vi>=0) m_package->setForksCount(vi);
+
+    vi = r.value("openIssuesCount").toInt(0);
+    if (vi>=0) m_package->setIssuesCount(vi);
+
+    vi = r.value("releases").toObject().value("count").toInt();
+    if (vi>=0) m_package->setReleasesCount(vi);
+
+    reply->deleteLater();
+  });
+}
+
+
+void ProjectGitLab::issue(const QString &issue_id, LoadableObject *value) {
+  if (value->ready() && value->valueId()==issue_id)
+    return; // value already corresponds to that release
+  value->reset(issue_id);
+
+  QString query = QStringLiteral(R"(
+{
+"query": "
+query {
+  project(fullPath: \"%1\") {
+    issue(iid: \"%2\") {
+      iid
+      title
+      author {
+        name
+        username
+      }
+      descriptionHtml
+      createdAt
+      updatedAt
+      notes {
+        nodes {
+          author {
+            name
+            username
+          }
+          bodyHtml
+          createdAt
+          updatedAt
+        }
+      }
+    }
+  }
+}"
+}
+)").arg(m_path, issue_id);
+
+  query = query.replace('\n', ' ');
+
+  QNetworkReply *reply = sendQuery(query);
+  connect(reply, &QNetworkReply::finished, [this, issue_id, reply, value](){
+    if (reply->error() != QNetworkReply::NoError) {
+      qWarning() << "GitLab: Failed to fetch issue for" << this->m_path;
+      qWarning() << "GitLab: Error: " << reply->errorString();
+    }
+
+    QByteArray data = reply->readAll();
+    QVariantMap r = QJsonDocument::fromJson(data).object().
+          value("data").toObject().value("project").toObject().
+          value("issue").toObject().toVariantMap();
+
+    QVariantMap result;
+    result["id"] = r.value("iid");
+    result["number"] = r.value("iid");
+    result["title"] = r.value("title");
+    QVariantList clist = r.value("notes").toMap().value("nodes").toList();
+    QVariantList result_list;
+    result["commentsCount"] = clist.size();
+    QVariantMap m;
+    m["author"] = getName(r.value("author"));
+    m["created"] = parseDate(r.value("createdAt").toString(), true);
+    m["updated"] = parseDate(r.value("updatedAt").toString(), true);
+    m["body"] = r.value("descriptionHtml").toString();
+    result_list.append(m);
+    // iterate in reverse as gitlab returns notes in reverse order
+    for (auto e=clist.rbegin(); e!=clist.rend(); ++e) {
+      QVariantMap element = e->toMap();
+      m.clear();
+      m["author"] = getName(element.value("author"));
+      m["created"] = parseDate(element.value("createdAt").toString(), true);
+      m["updated"] = parseDate(element.value("updatedAt").toString(), true);
+      m["body"] = element.value("bodyHtml").toString();
+      result_list.append(m);
+    }
+
+    result["discussion"] = result_list;
+    value->setValue(issue_id, result);
+    reply->deleteLater();
+  });
+}
+
+
+void ProjectGitLab::issues(LoadableObject *value) {
+  const QString issues_id{QStringLiteral("issues")};
+  value->reset(issues_id);
+
+  QString query = QStringLiteral(R"(
+{
+"query": "
+query {
+  project(fullPath: \"%1\") {
+    issues(state: opened, sort: UPDATED_DESC) {
+      nodes {
+        iid
+        title
+        author {
+          name
+          username
+        }
+        createdAt
+        updatedAt
+        notes {
+          nodes {
+            createdAt
+          }
+        }
+      }
+    }
+  }
+}"
+}
+)").arg(m_path);
+  query = query.replace('\n', ' ');
+
+  QNetworkReply *reply = sendQuery(query);
+  connect(reply, &QNetworkReply::finished, [this, issues_id, reply, value](){
+    if (reply->error() != QNetworkReply::NoError) {
+      qWarning() << "GitLab: Failed to fetch issues for" << this->m_path;
+      qWarning() << "GitLab: Error: " << reply->errorString();
+    }
+
+    QByteArray data = reply->readAll();
+    QVariantList r = QJsonDocument::fromJson(data).object().
+          value("data").toObject().value("project").toObject().
+          value("issues").toObject().value("nodes").toArray().toVariantList();
+
+    QVariantList rlist;
+    for (auto e: r) {
+      QVariantMap element = e.toMap();
+      QVariantMap m;
+      m["id"] = element.value("iid");
+      m["author"] = getName(element.value("author"));
+      m["commentsCount"] = element.value("notes").toMap().value("nodes").toList().size();
+      m["number"] = element.value("iid");
+      m["title"] = element.value("title");
+      m["created"] = parseDate(element.value("createdAt").toString(), true);
+      m["updated"] = parseDate(element.value("updatedAt").toString(), true);
+      rlist.append(m);
+    }
+
+    QVariantMap result;
+    result["issues"] = rlist;
+    value->setValue(issues_id, result);
+
+    reply->deleteLater();
+  });
+}
+
+
+void ProjectGitLab::release(const QString &release_id, LoadableObject *value) {
+  if (value->ready() && value->valueId()==release_id)
+    return; // value already corresponds to that release
+  value->reset(release_id);
+
+  QString query = QStringLiteral(R"(
+{
+"query": "
+query {
+  project(fullPath: \"%1\") {
+    release(tagName: \"%2\") {
+      name
+      createdAt
+      descriptionHtml
+    }
+  }
+}"
+}
+)").arg(m_path, release_id);
+
+  query = query.replace('\n', ' ');
+
+  QNetworkReply *reply = sendQuery(query);
+  connect(reply, &QNetworkReply::finished, [this, release_id, reply, value](){
+    if (reply->error() != QNetworkReply::NoError) {
+      qWarning() << "GitLab: Failed to fetch release for" << this->m_path;
+      qWarning() << "GitLab: Error: " << reply->errorString();
+    }
+
+    QByteArray data = reply->readAll();
+    QVariantMap r = QJsonDocument::fromJson(data).object().
+          value("data").toObject().value("project").toObject().
+          value("release").toObject().toVariantMap();
+
+    QVariantMap result;
+    result["name"] = r.value("name");
+    result["description"] = r.value("descriptionHtml");
+    result["datetime"] = parseDate(r.value("createdAt").toString());
+
+    value->setValue(release_id, result);
+    reply->deleteLater();
+  });
+}
+
+
+void ProjectGitLab::releases(LoadableObject *value) {
+  const QString releases_id{QStringLiteral("releases")};
+  value->reset(releases_id);
+
+  QString query = QStringLiteral(R"(
+{
+"query": "
+query {
+  project(fullPath: \"%1\") {
+    releases {
+      nodes {
+        name
+        tagName
+        createdAt
+      }
+    }
+  }
+}"
+}
+)").arg(m_path);
+  query = query.replace('\n', ' ');
+
+  QNetworkReply *reply = sendQuery(query);
+  connect(reply, &QNetworkReply::finished, [this, releases_id, reply, value](){
+    if (reply->error() != QNetworkReply::NoError) {
+      qWarning() << "GitLab: Failed to fetch releases for" << this->m_path;
+      qWarning() << "GitLab: Error: " << reply->errorString();
+    }
+
+    QByteArray data = reply->readAll();
+    QVariantList r = QJsonDocument::fromJson(data).object().
+          value("data").toObject().value("project").toObject().
+          value("releases").toObject().value("nodes").toArray().toVariantList();
+
+    QVariantList rlist;
+    for (auto e: r) {
+      QVariantMap element = e.toMap();
+      QVariantMap m;
+      m["id"] = element.value("tagName");
+      m["name"] = element.value("name");
+      m["datetime"] = parseDate(element.value("createdAt").toString());
+      rlist.append(m);
+    }
+
+    QVariantMap result;
+    result["releases"] = rlist;
+    value->setValue(releases_id, result);
+
+    reply->deleteLater();
+  });
+}

--- a/src/projectgitlab.h
+++ b/src/projectgitlab.h
@@ -1,0 +1,32 @@
+#ifndef PROJECTGITLAB_H
+#define PROJECTGITLAB_H
+
+#include <QObject>
+#include <QString>
+
+#include "projectabstract.h"
+
+class ProjectGitLab : public ProjectAbstract
+{
+  Q_OBJECT
+public:
+  explicit ProjectGitLab(const QString &url, ChumPackage *package);
+
+  static bool isProject(const QString &url);
+
+  virtual void issue(const QString &id, LoadableObject *value) override;
+  virtual void issues(LoadableObject *value) override;
+  virtual void release(const QString &id, LoadableObject *value) override;
+  virtual void releases(LoadableObject *value) override;
+
+signals:
+
+private:
+  void fetchRepoInfo();
+
+private:
+  QString m_path;
+
+};
+
+#endif // PROJECTGITLAB_H

--- a/translations/sailfishos-chum-gui.ts
+++ b/translations/sailfishos-chum-gui.ts
@@ -141,18 +141,24 @@
         <source>#%1 by %2</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="chum-issue-with-number">
+        <location filename="../qml/pages/IssuePage.qml" line="35"/>
+        <source>Issue: #%1</source>
+        <oldsource>Issue: %1</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="chum-issue">
-        <location filename="../qml/pages/IssuePage.qml" line="34"/>
+        <location filename="../qml/pages/IssuePage.qml" line="37"/>
         <source>Issue</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-issues-comments-number">
-        <location filename="../qml/pages/IssuePage.qml" line="72"/>
+        <location filename="../qml/pages/IssuePage.qml" line="75"/>
         <source>Comments: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-created-updated-datetime">
-        <location filename="../qml/pages/IssuePage.qml" line="119"/>
+        <location filename="../qml/pages/IssuePage.qml" line="122"/>
         <location filename="../qml/pages/IssuesListPage.qml" line="107"/>
         <source>Created: %1; Updated: %2</source>
         <translation type="unfinished"></translation>


### PR DESCRIPTION
This PR is on top of #27 - #27 is closed and let's review that work here as well.

This PR adds support for GitLab. As for GitHub, token is needed and is uploaded to OBS. When compared to GitHub, I couldn't find the way to get project owner for GitLab. Even members were not always listed for the project, that depended on the project as far as I could see. So, author would have to be specified in RPM SPEC metadata section.

In addition, from #27, GitHub and GitLab support is enabled automatically if RPM SPEC URL points to corresponding repo. Which is for quite some number of projects that we have in Chum, about 90 as far as I counted.

Finally, from #27, package list model is extended to allow showing packages which can be updated. Such indicator is used in official and OpenRepos stores.

Please review when you have time.

Fixes #11 , related to #26