### PR TITLE
Manage Chum repositories from GUI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ add_custom_target(distfiles SOURCES
   qml/pages/ReleasePage.qml
   qml/pages/ReleasesListPage.qml
   qml/pages/ScreenshotPage.qml
+  qml/pages/SettingsPage.qml
   qml/components/AppInformation.qml
   qml/components/ChumDetailItem.qml
   qml/components/FancyPageHeader.qml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,6 @@ project(sailfishos-chum-gui
   VERSION   ${CHUMGUI_VERSION}
 )
 
-set(REPO "sailfishos-chum" CACHE STRING "Alias of the repository")
 set(GITHUB_TOKEN "unset" CACHE STRING "GitHub access token for GraphQL queries")
 set(GITLAB_TOKEN "unset" CACHE STRING "GitLab.com access token for GraphQL queries")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ add_custom_target(distfiles SOURCES
   qml/pages/IssuePage.qml
   qml/pages/IssuesListPage.qml
   qml/pages/MainPage.qml
+  qml/pages/MessagePage.qml
   qml/pages/PackagePage.qml
   qml/pages/PackagesListPage.qml
   qml/pages/ReleasePage.qml

--- a/qml/pages/MainPage.qml
+++ b/qml/pages/MainPage.qml
@@ -43,7 +43,14 @@ Page {
 
       MenuItem {
         enabled: !Chum.busy
-        //% "Refresh cache"
+        //% "Settings"
+        text: qsTrId("chum-settings-title")
+        onClicked: pageStack.push(Qt.resolvedUrl("SettingsPage.qml"))
+      }
+
+      MenuItem {
+        enabled: !Chum.busy
+        //% "Refresh repository"
         text: qsTrId("chum-refresh-cache")
         onClicked: Chum.refreshRepo()
       }

--- a/qml/pages/MessagePage.qml
+++ b/qml/pages/MessagePage.qml
@@ -16,6 +16,7 @@ Page {
 
         Column {
             id: content
+            spacing: Theme.paddingLarge
             width: parent.width
 
             PageHeader {

--- a/qml/pages/MessagePage.qml
+++ b/qml/pages/MessagePage.qml
@@ -1,0 +1,38 @@
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import org.chum 1.0
+import "../components"
+
+Page {
+    id: page
+    allowedOrientations: Orientation.All
+
+    property string title
+    property string text
+
+    SilicaFlickable {
+        anchors.fill: parent
+        contentHeight: content.height + Theme.paddingLarge
+
+        Column {
+            id: content
+            width: parent.width
+
+            PageHeader {
+                title: page.title
+            }
+
+            Label {
+                anchors {
+                    left: parent.left
+                    leftMargin: Theme.horizontalPageMargin
+                    right: parent.right
+                    rightMargin: Theme.horizontalPageMargin
+                }
+                color: Theme.primaryColor
+                text: page.text
+                wrapMode: Text.WordWrap
+            }
+        }
+    }
+}

--- a/qml/pages/PackagesListPage.qml
+++ b/qml/pages/PackagesListPage.qml
@@ -62,15 +62,6 @@ Page {
       search: page.search
     }
 
-    PullDownMenu {
-      busy: Chum.busy
-      MenuItem {
-        //% "Reload"
-        text: qsTrId("chum-reload")
-        onClicked: chumModel.reset()
-      }
-    }
-
     VerticalScrollDecorator {}
   }
 }

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -1,0 +1,60 @@
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import org.chum 1.0
+import "../components"
+
+Page {
+    id: page
+    allowedOrientations: Orientation.All
+
+    SilicaFlickable {
+        anchors.fill: parent
+        contentHeight: content.height + Theme.paddingLarge
+
+        Column {
+            id: content
+            spacing: Theme.paddingLarge
+            width: parent.width
+
+            PageHeader {
+                //% "Settings"
+                title: qsTrId("chum-settings-title")
+            }
+
+            Label {
+                anchors {
+                    left: parent.left
+                    leftMargin: Theme.horizontalPageMargin
+                    right: parent.right
+                    rightMargin: Theme.horizontalPageMargin
+                }
+                color: Theme.highlightColor
+                text: {
+                    if (!Chum.repoManaged) {
+                        //% "Chum repository management failed"
+                        return qsTrId("chum-settings-status-repo-management-failed");
+                    }
+                    return Chum.repoAvailable ?
+                          //% "Current status: Chum repository available"
+                          qsTrId("chum-settings-status-repo-available") :
+                          //% "Current status: Chum repository is not available"
+                          qsTrId("chum-settings-status-repo-not-available");
+                }
+                wrapMode: Text.WordWrap
+            }
+
+            TextSwitch {
+                automaticCheck: false
+                busy: Chum.busy
+                checked: Chum.repoTesting
+                //% "Use testing version of Chum repository. This is mainly useful for developers "
+                //% "for testing their packages before publishing."
+                description: qsTrId("chum-settings-testing-description")
+                //% "Use testing repository"
+                text: qsTrId("chum-settings-testing")
+
+                onClicked: Chum.repoTesting = !Chum.repoTesting;
+            }
+        }
+    }
+}

--- a/qml/sailfishos-chum-gui.qml
+++ b/qml/sailfishos-chum-gui.qml
@@ -67,10 +67,11 @@ ApplicationWindow {
     onError: notification.show(errorTxt)
 
     onErrorFatal: {
-        pageStack.replace(Qt.resolvedUrl("pages/MessagePage.qml"), {
-                            title: errorTitle,
-                            text: errorTxt
-                          });
+        pageStack.replaceAbove(null,
+                               Qt.resolvedUrl("pages/MessagePage.qml"), {
+                                   title: errorTitle,
+                                   text: errorTxt
+                               });
     }
 
     onRepositoryRefreshed: {

--- a/qml/sailfishos-chum-gui.qml
+++ b/qml/sailfishos-chum-gui.qml
@@ -66,6 +66,13 @@ ApplicationWindow {
 
     onError: notification.show(errorTxt)
 
+    onErrorFatal: {
+        pageStack.replace(Qt.resolvedUrl("pages/MessagePage.qml"), {
+                            title: errorTitle,
+                            text: errorTxt
+                          });
+    }
+
     onRepositoryRefreshed: {
       //% "Repository refreshed"
       notification.show(qsTrId("chum-repo-refreshed"))

--- a/rpm/sailfishos-chum-gui.spec
+++ b/rpm/sailfishos-chum-gui.spec
@@ -1,5 +1,3 @@
-#define chum_testing_repo 1
-
 Name:           sailfishos-chum-gui
 Summary:        Chum GUI
 Version:        0.2.0
@@ -11,11 +9,6 @@ Source0:        %{name}-%{version}.tar.bz2
 Source1:        token-github.txt
 Source2:        token-gitlab.txt
 Requires:       sailfishsilica-qt5 >= 0.10.9
-%if 0%{?chum_testing_repo}
-Requires:       sailfishos-chum-testing
-%else
-Requires:       sailfishos-chum
-%endif
 BuildRequires:  pkgconfig(sailfishapp) >= 1.0.2
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Qml)
@@ -37,9 +30,6 @@ A client app for the Chum repositories
 %cmake -DCHUMGUI_VERSION=%(echo %{version} | grep -Eo '^[0-9]+(\.[0-9]+)*') \
        -DGITHUB_TOKEN=%(cat token-github.txt)  \
        -DGITLAB_TOKEN=%(cat token-gitlab.txt)  \
-%if 0%{?chum_testing_repo}
-       -DREPO=sailfishos-chum-testing \
-%endif
      .
 cmake --build .
 

--- a/rpm/sailfishos-chum-gui.spec
+++ b/rpm/sailfishos-chum-gui.spec
@@ -9,6 +9,7 @@ Source0:        %{name}-%{version}.tar.bz2
 Source1:        token-github.txt
 Source2:        token-gitlab.txt
 Requires:       sailfishsilica-qt5 >= 0.10.9
+Requires:       ssu
 BuildRequires:  pkgconfig(sailfishapp) >= 1.0.2
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Qml)
@@ -39,6 +40,12 @@ rm -rf %{buildroot}
 desktop-file-install --delete-original       \
   --dir %{buildroot}%{_datadir}/applications \
    %{buildroot}%{_datadir}/applications/*.desktop
+
+%postun
+ssu rr sailfishos-chum || true
+ssu rr sailfishos-chum-testing || true
+rm -f /var/cache/ssu/features.ini || true
+ssu ur || true
 
 %files
 %defattr(-,root,root,-)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,8 @@ add_executable(${PROJECT_NAME}
   projectgithub.h
   projectgitlab.cpp
   projectgitlab.h
+  ssu.cpp
+  ssu.h
   main.cpp
   main.h
 )

--- a/src/chum.cpp
+++ b/src/chum.cpp
@@ -7,7 +7,6 @@
 using namespace PackageKit;
 
 Chum* Chum::s_instance{nullptr};
-const QString Chum::s_repo_name{QStringLiteral(REPO_ALIAS)};
 
 #define SET_STATUS(status) { \
   if (m_status != status) {  \
@@ -29,9 +28,16 @@ static inline auto role2operation(Transaction::Role role) {
 }
 
 Chum::Chum(QObject *parent)
-  : QObject{parent} {
+  : QObject{parent}
+{
+  connect(&m_ssu, &Ssu::updated, this, &Chum::repositoriesListUpdated);
+  connect(&m_ssu, &Ssu::updated, this, &Chum::repoUpdated);
   connect(Daemon::global(), &Daemon::updatesChanged, [this]() { this->getUpdates(); });
-  refreshPackages();
+
+  m_busy = true;
+  //% "Load repositories"
+  SET_STATUS(qtTrId("chum-load-repositories"));
+  m_ssu.loadRepos();
 }
 
 Chum* Chum::instance() {
@@ -72,7 +78,7 @@ void Chum::refreshPackages() {
           [[maybe_unused]] const QString &summary
           ) {
     QString pd = Daemon::packageData(packageID);
-    if (pd == s_repo_name)
+    if (pd == m_ssu.repoName())
       m_packages_last_refresh.insert(packageID);
     else if (pd == QStringLiteral("installed"))
       m_packages_last_refresh_installed.insert(packageID);
@@ -94,7 +100,7 @@ void Chum::refreshPackagesInstalled()
           [[maybe_unused]] const QString &summary
           ) {
     QString pd = Daemon::packageData(packageID);
-    if (pd == s_repo_name)
+    if (pd == m_ssu.repoName())
       m_packages_last_refresh.insert(packageID);
   });
   connect(tr, &Transaction::finished, this, &Chum::refreshPackagesFinished);
@@ -248,11 +254,11 @@ void Chum::refreshRepo(bool force) {
     emit busyChanged();
   }
 
-  //% "Refresh repositories"
+  //% "Refreshing Chum repository"
   SET_STATUS(qtTrId("chum-refresh-repository"));
 
   auto pktr = Daemon::repoSetData(
-    s_repo_name,
+    m_ssu.repoName(),
     QStringLiteral("refresh-now"),
     QVariant::fromValue(force).toString()
   );
@@ -261,6 +267,43 @@ void Chum::refreshRepo(bool force) {
     refreshPackages();
     emit this->repositoryRefreshed();
   });
+  connect(pktr, &Transaction::errorCode,
+          [this](PackageKit::Transaction::Error /*error*/, const QString &details){
+      qWarning() << "Failed to refresh Chum repository" << details;
+      //% "Failed to refresh Chum repository"
+      emit error(qtTrId("chum-refresh-repository-failed"));
+  });
+}
+
+void Chum::repositoriesListUpdated() {
+  if (!m_ssu.manageRepo()) {
+      // repos are managed outside of GUI, probably misconfiguration
+      //% "Cannot manage Chum repositories through GUI"
+      emit error(qtTrId("chum-repo-management-disabled"));
+  } else if (!m_ssu.repoAvailable()) {
+      m_busy = true;
+      emit busyChanged();
+      //% "Adding Chum repository"
+      SET_STATUS(qtTrId("chum-add-repo"));
+      m_ssu.setRepo();
+      return;
+  }
+  refreshRepo(true);
+}
+
+void Chum::setRepoTesting(bool testing) {
+  if (!m_ssu.manageRepo()) {
+      emit error(qtTrId("chum-repo-management-disabled"));
+      return;
+  }
+
+  if (!m_ssu.repoAvailable() || m_ssu.repoTesting() != testing) {
+      m_busy = true;
+      emit busyChanged();
+      //% "Setting up Chum repository"
+      SET_STATUS(qtTrId("chum-setup-repo"));
+      m_ssu.setRepo(testing);
+  }
 }
 
 // operations on packages

--- a/src/chum.cpp
+++ b/src/chum.cpp
@@ -248,6 +248,11 @@ void Chum::getUpdates(bool force) {
 // refresh repository and call package info updates
 void Chum::refreshRepo(bool force) {
   if (m_busy && !force) return;
+  if (!m_ssu.repoAvailable()) {
+      //% "Cannot refresh repository as it is not available"
+      emit error(qtTrId("chum-refresh-repository-impossible"));
+      return;
+  }
 
   if (!m_busy) {
     m_busy = true;
@@ -278,8 +283,15 @@ void Chum::refreshRepo(bool force) {
 void Chum::repositoriesListUpdated() {
   if (!m_ssu.manageRepo()) {
       // repos are managed outside of GUI, probably misconfiguration
-      //% "Cannot manage Chum repositories through GUI"
-      emit error(qtTrId("chum-repo-management-disabled"));
+      emit errorFatal(
+            //% "Repositories misconfigured"
+            qtTrId("chum-repo-management-disabled-title"),
+            //% "Cannot manage Chum repositories through GUI. You probably have multiple Chum "
+            //% "repositories defined in SSU or Chum repository disabled.\n\n"
+            //% "Please remove all defined Chum repositories and restart GUI. "
+            //% "GUI will add missing Chum repository if needed on restart."
+            qtTrId("chum-repo-management-disabled-txt"));
+      return;
   } else if (!m_ssu.repoAvailable()) {
       m_busy = true;
       emit busyChanged();

--- a/src/chum.cpp
+++ b/src/chum.cpp
@@ -287,7 +287,8 @@ void Chum::repositoriesListUpdated() {
             //% "Repositories misconfigured"
             qtTrId("chum-repo-management-disabled-title"),
             //% "Cannot manage Chum repositories through GUI. You probably have multiple Chum "
-            //% "repositories defined in SSU or Chum repository disabled.\n\n"
+            //% "repositories defined in SSU or Chum repository disabled. For listing repositories "
+            //% "and their removal, use 'ssu' command in terminal.\n\n"
             //% "Please remove all defined Chum repositories and restart GUI. "
             //% "GUI will add missing Chum repository if needed on restart."
             qtTrId("chum-repo-management-disabled-txt"));

--- a/src/chum.h
+++ b/src/chum.h
@@ -52,6 +52,7 @@ public slots:
 signals:
   void busyChanged();
   void error(QString errorTxt);
+  void errorFatal(QString errorTitle, QString errorTxt);
   void statusChanged();
   void updatesCountChanged();
   void packagesChanged();

--- a/src/chum.h
+++ b/src/chum.h
@@ -5,6 +5,7 @@
 #include <QSet>
 
 #include "chumpackage.h"
+#include "ssu.h"
 
 namespace PackageKit {
 class Transaction;
@@ -13,6 +14,9 @@ class Transaction;
 class Chum : public QObject {
   Q_OBJECT
   Q_PROPERTY(bool    busy READ busy NOTIFY busyChanged)
+  Q_PROPERTY(bool    repoAvailable READ repoAvailable NOTIFY repoUpdated)
+  Q_PROPERTY(bool    repoManaged READ repoManaged NOTIFY repoUpdated)
+  Q_PROPERTY(bool    repoTesting READ repoTesting WRITE setRepoTesting NOTIFY repoUpdated)
   Q_PROPERTY(QString status READ status NOTIFY statusChanged)
   Q_PROPERTY(quint32 updatesCount   READ updatesCount NOTIFY updatesCountChanged)
 
@@ -24,10 +28,14 @@ public:
   };
   Q_ENUM(PackageOperation)
 
-  // repo operations
-  bool busy() const { return m_busy; }
+  bool    busy() const { return m_busy; }
+  bool    repoAvailable() const { return m_ssu.repoAvailable(); }
+  bool    repoManaged() const { return m_ssu.manageRepo(); }
+  bool    repoTesting() const { return m_ssu.repoTesting(); }
   QString status() const { return m_status; }
   quint32 updatesCount() const { return m_updates_count; }
+
+  void    setRepoTesting(bool testing);
 
   QList<ChumPackage*> packages() const { return m_packages.values(); }
   Q_INVOKABLE ChumPackage* package(const QString &id) const { return m_packages.value(id, nullptr); }
@@ -49,12 +57,15 @@ signals:
   void packagesChanged();
   void packageOperationStarted( PackageOperation operation, const QString &name);
   void packageOperationFinished(PackageOperation operation, const QString &name, const QString &version);
+  void repoUpdated(); // signal ssu properties change
   void repositoryRefreshed();
 
 private:
   explicit Chum(QObject *parent = nullptr);
 
   QString packageId(const QString &pkg_id);
+
+  void repositoriesListUpdated();
 
   void getUpdatesFinished();
   void refreshPackages();
@@ -66,6 +77,7 @@ private:
   void startOperation(PackageKit::Transaction *pktr, const QString &pkg_id);
 
 private:
+  Ssu           m_ssu;
   bool          m_busy{false};
   QString       m_status;
   quint32       m_updates_count{0};

--- a/src/ssu.cpp
+++ b/src/ssu.cpp
@@ -51,7 +51,7 @@ void Ssu::onListFinished(QDBusPendingCallWatcher *call) {
       QVariantMap pars;
       arg >> name >> url >> pars;
       arg.endStructure();
-      qDebug() << name << url << pars;
+      //qDebug() << name << url << pars;
       std::pair<QString,QString> r(name, url);
       m_repos.append(r);
     }
@@ -86,7 +86,18 @@ void Ssu::onListFinished(QDBusPendingCallWatcher *call) {
 
   m_manage_repo = true;
 
-  qDebug() << m_manage_repo << m_repo_testing << m_repo_name;
+  // Check if addition worked out as expected
+  if (!m_added_repo_name.isEmpty() && m_added_repo_name != m_repo_name) {
+    qWarning() << "Failed to add new repository with alias " << m_added_repo_name;
+    qWarning() << "Check whether this alias has been defined by SSU in enabled or disabled repositories";
+    qWarning() << "Remove such repository definition from SSU if it is there";
+    m_manage_repo = false;
+    emit updated();
+    return;
+  }
+  m_added_repo_name.clear();
+
+  qDebug() << "SSU repo:" << m_manage_repo << m_repo_testing << m_repo_name;
 
   emit updated();
 }
@@ -127,6 +138,7 @@ void Ssu::setRepo(bool testing) {
   callWithArgumentList(QDBus::BlockWithGui, QStringLiteral("addRepo"),
                        QVariantList{rname, url});
   call(QDBus::BlockWithGui, QStringLiteral("updateRepos"));
+  m_added_repo_name = rname;
 
   // refresh list
   loadRepos();

--- a/src/ssu.cpp
+++ b/src/ssu.cpp
@@ -1,0 +1,133 @@
+#include "ssu.h"
+
+#include <QDBusPendingCall>
+#include <QDBusPendingReply>
+#include <QDebug>
+
+static QString s_repo_regular(
+    QStringLiteral("https://repo.sailfishos.org/obs/sailfishos:/chum/%(release)_%(arch)/"));
+static QString s_repo_regular_prefix(
+    QStringLiteral("https://repo.sailfishos.org/obs/sailfishos:/chum/"));
+static QString s_repo_testing(
+    QStringLiteral("https://repo.sailfishos.org/obs/sailfishos:/chum:/testing/%(release)_%(arch)/"));
+static QString s_repo_testing_prefix(
+    QStringLiteral("https://repo.sailfishos.org/obs/sailfishos:/chum:/testing/"));
+
+Ssu::Ssu(QObject *parent) :
+  QDBusAbstractInterface(
+    QStringLiteral("org.nemo.ssu"),
+    QStringLiteral("/org/nemo/ssu"),
+    "org.nemo.ssu",
+    QDBusConnection::systemBus(),
+    parent )
+{
+}
+
+void Ssu::loadRepos() {
+  // rnd set to false to have repos with the version instead of "latest"
+  QDBusPendingCall pcall = asyncCall(QStringLiteral("listRepos"), false);
+  QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(pcall, this);
+  QObject::connect(watcher, &QDBusPendingCallWatcher::finished,
+                   this, &Ssu::onListFinished);
+}
+
+void Ssu::onListFinished(QDBusPendingCallWatcher *call) {
+  m_repos.clear();
+
+  // load repos from DBus call
+  QVariantList vlist = call->reply().arguments();
+  if (vlist.length() != 1) {
+      qWarning() << "Unexpected reply from SSU:" << call->reply();
+      m_manage_repo = false;
+      emit updated();
+      return;
+  }
+  const QDBusArgument &arg = vlist[0].value<QDBusArgument>();
+  arg.beginArray();
+  while (!arg.atEnd()) {
+      arg.beginStructure();
+      QString name;
+      QString url;
+      QVariantMap pars;
+      arg >> name >> url >> pars;
+      arg.endStructure();
+      qDebug() << name << url << pars;
+      std::pair<QString,QString> r(name, url);
+      m_repos.append(r);
+    }
+  arg.endArray();
+
+  // count chum repos
+  int count = 0;
+  bool has_reg = false;
+  QString repo_name;
+  for (const auto &u: m_repos)
+    if (u.second.startsWith(s_repo_regular_prefix)) {
+        ++count;
+        has_reg = true;
+        repo_name = u.first;
+    } else if (u.second.startsWith(s_repo_testing_prefix)) {
+        ++count;
+        repo_name = u.first;
+    }
+
+  if (count > 1) {
+      qWarning() << "More than one Chum repository defined in SSU - skipping management of repositories";
+      m_manage_repo = false;
+      emit updated();
+      return;
+  }
+
+  if (has_reg) m_repo_testing = false;
+  else if (count == 1) m_repo_testing = true;
+
+  if (count == 1) m_repo_name = repo_name;
+  else m_repo_name.clear();
+
+  m_manage_repo = true;
+
+  qDebug() << m_manage_repo << m_repo_testing << m_repo_name;
+
+  emit updated();
+}
+
+void Ssu::setRepo(bool testing) {
+  if (!m_manage_repo) {
+      qWarning() << "Cannot set repository via SSU - management disabled";
+      return;
+  }
+
+  if (repoAvailable()) {
+      // remove current repository
+      callWithArgumentList(QDBus::BlockWithGui, QStringLiteral("modifyRepo"),
+                           QVariantList{0, m_repo_name});
+  }
+
+  // find new repo name
+  QString rname = testing ? QStringLiteral("sailfishos-chum-testing") :
+                            QStringLiteral("sailfishos-chum");
+  QString url = testing ? s_repo_testing : s_repo_regular;
+  if (rname != m_repo_name) {
+      // check if proposed name is taken
+      for (bool done=false; !done; ) {
+          done = true;
+          for (const auto &u: m_repos) {
+              if (u.first == rname) {
+                  rname.append(QStringLiteral("-gui"));
+                  done = false;
+                  break; // check new name
+              }
+          }
+      }
+  }
+
+  m_repo_name.clear();
+
+  // add repo
+  callWithArgumentList(QDBus::BlockWithGui, QStringLiteral("addRepo"),
+                       QVariantList{rname, url});
+  call(QDBus::BlockWithGui, QStringLiteral("updateRepos"));
+
+  // refresh list
+  loadRepos();
+}

--- a/src/ssu.h
+++ b/src/ssu.h
@@ -32,6 +32,7 @@ private:
   QString m_repo_name;
 
   QList< std::pair<QString,QString> > m_repos;
+  QString m_added_repo_name;
 };
 
 #endif // SSU_H

--- a/src/ssu.h
+++ b/src/ssu.h
@@ -1,0 +1,37 @@
+#ifndef SSU_H
+#define SSU_H
+
+#include <QDBusAbstractInterface>
+#include <QDBusPendingCallWatcher>
+#include <QList>
+#include <utility>
+
+class Ssu : public QDBusAbstractInterface
+{
+  Q_OBJECT
+public:
+  explicit Ssu(QObject *parent = nullptr);
+
+  bool manageRepo() const { return m_manage_repo; }
+  bool repoAvailable() const { return m_manage_repo && !m_repo_name.isEmpty(); }
+  bool repoTesting() const { return m_manage_repo && m_repo_testing; }
+  QString repoName() const { return m_manage_repo ? m_repo_name : QString{}; }
+
+  void loadRepos();
+  void setRepo(bool testing=false);
+
+signals:
+  void updated();
+
+private:
+  void onListFinished(QDBusPendingCallWatcher *call);
+
+private:
+  bool m_manage_repo{false};
+  bool m_repo_testing{false};
+  QString m_repo_name;
+
+  QList< std::pair<QString,QString> > m_repos;
+};
+
+#endif // SSU_H

--- a/translations/sailfishos-chum-gui.ts
+++ b/translations/sailfishos-chum-gui.ts
@@ -90,38 +90,65 @@
         <source>Releases</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="chum-load-repositories">
+        <location filename="../src/chum.cpp" line="39"/>
+        <source>Load repositories</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="chum-get-list-packages">
-        <location filename="../src/chum.cpp" line="68"/>
+        <location filename="../src/chum.cpp" line="74"/>
         <source>Get list of packages</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-get-package-details">
-        <location filename="../src/chum.cpp" line="139"/>
+        <location filename="../src/chum.cpp" line="145"/>
         <source>Get package details</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-get-package-version">
-        <location filename="../src/chum.cpp" line="169"/>
+        <location filename="../src/chum.cpp" line="175"/>
         <source>Get versions of installed packages</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-check-updates">
-        <location filename="../src/chum.cpp" line="211"/>
+        <location filename="../src/chum.cpp" line="217"/>
         <source>Check for updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-refresh-repository">
-        <location filename="../src/chum.cpp" line="252"/>
-        <source>Refresh repositories</source>
+        <location filename="../src/chum.cpp" line="258"/>
+        <source>Refresh Chum repository</source>
+        <oldsource>Refresh repositories</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="chum-refresh-repository-failed">
+        <location filename="../src/chum.cpp" line="274"/>
+        <source>Failed to refresh Chum repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="chum-repo-management-disabled">
+        <location filename="../src/chum.cpp" line="282"/>
+        <location filename="../src/chum.cpp" line="296"/>
+        <source>Cannot manage Chum repositories through GUI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="chum-add-repo">
+        <location filename="../src/chum.cpp" line="287"/>
+        <source>Adding Chum repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="chum-setup-repo">
+        <location filename="../src/chum.cpp" line="304"/>
+        <source>Setting up Chum repository</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-install-package">
-        <location filename="../src/chum.cpp" line="272"/>
+        <location filename="../src/chum.cpp" line="315"/>
         <source>Install package</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-update-package">
-        <location filename="../src/chum.cpp" line="281"/>
+        <location filename="../src/chum.cpp" line="324"/>
         <source>Update package</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/sailfishos-chum-gui.ts
+++ b/translations/sailfishos-chum-gui.ts
@@ -4,21 +4,14 @@
 <context>
     <name></name>
     <message id="chum-available-packages">
-        <location filename="../qml/pages/MainPage.qml" line="74"/>
-        <location filename="../qml/pages/MainPage.qml" line="78"/>
-        <location filename="../qml/pages/SettingsPage.qml" line="74"/>
-        <location filename="../qml/pages/SettingsPage.qml" line="78"/>
+        <location filename="../qml/pages/MainPage.qml" line="81"/>
+        <location filename="../qml/pages/MainPage.qml" line="85"/>
         <source>Available packages</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-search">
         <location filename="../qml/pages/PackagesListPage.qml" line="31"/>
         <source>Search</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="chum-reload">
-        <location filename="../qml/pages/PackagesListPage.qml" line="69"/>
-        <source>Reload</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-updates-available" numerus="yes">
@@ -30,7 +23,7 @@
         </translation>
     </message>
     <message id="chum-repo-refreshed">
-        <location filename="../qml/sailfishos-chum-gui.qml" line="78"/>
+        <location filename="../qml/sailfishos-chum-gui.qml" line="79"/>
         <source>Repository refreshed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,19 +41,17 @@
     </message>
     <message id="chum-about">
         <location filename="../qml/pages/MainPage.qml" line="41"/>
-        <location filename="../qml/pages/SettingsPage.qml" line="41"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-refresh-cache">
-        <location filename="../qml/pages/MainPage.qml" line="47"/>
-        <location filename="../qml/pages/SettingsPage.qml" line="47"/>
-        <source>Refresh cache</source>
+        <location filename="../qml/pages/MainPage.qml" line="54"/>
+        <source>Refresh repository</source>
+        <oldsource>Refresh cache</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-no-updates">
-        <location filename="../qml/pages/MainPage.qml" line="65"/>
-        <location filename="../qml/pages/SettingsPage.qml" line="65"/>
+        <location filename="../qml/pages/MainPage.qml" line="72"/>
         <source>No updates available</source>
         <oldsource>No update available</oldsource>
         <translation type="unfinished"></translation>
@@ -142,38 +133,38 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-repo-management-disabled-txt">
-        <location filename="../src/chum.cpp" line="293"/>
-        <source>Cannot manage Chum repositories through GUI. You probably have multiple Chum repositories defined in SSU or Chum repository disabled.
+        <location filename="../src/chum.cpp" line="294"/>
+        <source>Cannot manage Chum repositories through GUI. You probably have multiple Chum repositories defined in SSU or Chum repository disabled. For listing repositories and their removal, use &apos;ssu&apos; command in terminal.
 
 Please remove all defined Chum repositories and restart GUI. GUI will add missing Chum repository if needed on restart.</source>
-        <oldsource>Cannot manage Chum repositories through GUI. You probably have multiple Chum repositories defined in SSU. Please remove all defined repositories and restart GUI. GUI will add missing Chum repository if needed on restart.
+        <oldsource>Cannot manage Chum repositories through GUI. You probably have multiple Chum repositories defined in SSU or Chum repository disabled.
 
-</oldsource>
+Please remove all defined Chum repositories and restart GUI. GUI will add missing Chum repository if needed on restart.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-repo-management-disabled">
-        <location filename="../src/chum.cpp" line="308"/>
+        <location filename="../src/chum.cpp" line="309"/>
         <source></source>
         <oldsource>Cannot manage Chum repositories through GUI</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-add-repo">
-        <location filename="../src/chum.cpp" line="299"/>
+        <location filename="../src/chum.cpp" line="300"/>
         <source>Adding Chum repository</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-setup-repo">
-        <location filename="../src/chum.cpp" line="316"/>
+        <location filename="../src/chum.cpp" line="317"/>
         <source>Setting up Chum repository</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-install-package">
-        <location filename="../src/chum.cpp" line="327"/>
+        <location filename="../src/chum.cpp" line="328"/>
         <source>Install package</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-update-package">
-        <location filename="../src/chum.cpp" line="336"/>
+        <location filename="../src/chum.cpp" line="337"/>
         <source>Update package</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/sailfishos-chum-gui.ts
+++ b/translations/sailfishos-chum-gui.ts
@@ -6,6 +6,8 @@
     <message id="chum-available-packages">
         <location filename="../qml/pages/MainPage.qml" line="74"/>
         <location filename="../qml/pages/MainPage.qml" line="78"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="74"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="78"/>
         <source>Available packages</source>
         <translation type="unfinished"></translation>
     </message>
@@ -28,7 +30,7 @@
         </translation>
     </message>
     <message id="chum-repo-refreshed">
-        <location filename="../qml/sailfishos-chum-gui.qml" line="71"/>
+        <location filename="../qml/sailfishos-chum-gui.qml" line="78"/>
         <source>Repository refreshed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -46,16 +48,19 @@
     </message>
     <message id="chum-about">
         <location filename="../qml/pages/MainPage.qml" line="41"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="41"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-refresh-cache">
         <location filename="../qml/pages/MainPage.qml" line="47"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="47"/>
         <source>Refresh cache</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-no-updates">
         <location filename="../qml/pages/MainPage.qml" line="65"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="65"/>
         <source>No updates available</source>
         <oldsource>No update available</oldsource>
         <translation type="unfinished"></translation>
@@ -115,40 +120,60 @@
         <source>Check for updates</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="chum-refresh-repository-impossible">
+        <location filename="../src/chum.cpp" line="253"/>
+        <source>Cannot refresh repository as it is not available</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="chum-refresh-repository">
-        <location filename="../src/chum.cpp" line="258"/>
-        <source>Refresh Chum repository</source>
-        <oldsource>Refresh repositories</oldsource>
+        <location filename="../src/chum.cpp" line="263"/>
+        <source>Refreshing Chum repository</source>
+        <oldsource>Refresh Chum repository</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-refresh-repository-failed">
-        <location filename="../src/chum.cpp" line="274"/>
+        <location filename="../src/chum.cpp" line="279"/>
         <source>Failed to refresh Chum repository</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="chum-repo-management-disabled-title">
+        <location filename="../src/chum.cpp" line="288"/>
+        <source>Repositories misconfigured</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="chum-repo-management-disabled-txt">
+        <location filename="../src/chum.cpp" line="293"/>
+        <source>Cannot manage Chum repositories through GUI. You probably have multiple Chum repositories defined in SSU or Chum repository disabled.
+
+Please remove all defined Chum repositories and restart GUI. GUI will add missing Chum repository if needed on restart.</source>
+        <oldsource>Cannot manage Chum repositories through GUI. You probably have multiple Chum repositories defined in SSU. Please remove all defined repositories and restart GUI. GUI will add missing Chum repository if needed on restart.
+
+</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="chum-repo-management-disabled">
-        <location filename="../src/chum.cpp" line="282"/>
-        <location filename="../src/chum.cpp" line="296"/>
-        <source>Cannot manage Chum repositories through GUI</source>
+        <location filename="../src/chum.cpp" line="308"/>
+        <source></source>
+        <oldsource>Cannot manage Chum repositories through GUI</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-add-repo">
-        <location filename="../src/chum.cpp" line="287"/>
+        <location filename="../src/chum.cpp" line="299"/>
         <source>Adding Chum repository</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-setup-repo">
-        <location filename="../src/chum.cpp" line="304"/>
+        <location filename="../src/chum.cpp" line="316"/>
         <source>Setting up Chum repository</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-install-package">
-        <location filename="../src/chum.cpp" line="315"/>
+        <location filename="../src/chum.cpp" line="327"/>
         <source>Install package</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-update-package">
-        <location filename="../src/chum.cpp" line="324"/>
+        <location filename="../src/chum.cpp" line="336"/>
         <source>Update package</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
This is to be reviewed and merged after #29 as it was built on the top of it. Would have to rebase before review as well.

This PR adds Chum repository handling to GUI. It is expected that GUI will be the only one adding and modifying repos and we should ask users to uninstall sailfishos-chum (or testing variant) as it may get into trouble with that.

In short, GUI now
- finds which ssu repos are defined and determines whether chum repo is the regular or testing
- when no chum repo is defined, it adds the regular chum repo
- allows to switch between testing and regular repo

It handles several error conditions, such as multiple Chum repos defined (some developers may have it), if it cannot add repo due to some conflict (usually disabled ssu repo with the same name).

On uninstall, Chum repositories are removed using their common names. If some unusual name was used instead, such removal will fail.

Fixes #21