### PR TITLE
Packages: show installed; allow to uninstall; sync info with changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ add_custom_target(distfiles SOURCES
   qml/pages/ScreenshotPage.qml
   qml/pages/SettingsPage.qml
   qml/components/AppInformation.qml
+  qml/components/AppSummary.qml
   qml/components/ChumDetailItem.qml
   qml/components/FancyPageHeader.qml
   qml/components/ImageLabel.qml

--- a/qml/components/AppInformation.qml
+++ b/qml/components/AppInformation.qml
@@ -30,24 +30,19 @@ MouseArea {
             rightMargin: Theme.horizontalPageMargin
         }
 
-        Item {
+        Label {
+            id: bodyLabel
             width: parent.width
-            height: bodyLabel.height
-
-            Label {
-                id: bodyLabel
-                width: parent.width
-                text: pkg.description
-                color: infoItem.pressed ? Theme.highlightColor : Theme.primaryColor
-                linkColor: Theme.highlightColor
-                wrapMode: Text.WordWrap
-                onLinkActivated: openLink(link)
-            }
+            text: pkg.description
+            color: infoItem.pressed ? Theme.highlightColor : Theme.primaryColor
+            linkColor: Theme.highlightColor
+            wrapMode: Text.WordWrap
+            onLinkActivated: openLink(link)
         }
 
         Item {
             id: spacer
-            height: Theme.paddingMedium
+            height: Theme.paddingLarge
         }
 
         ChumDetailItem {

--- a/qml/components/AppInformation.qml
+++ b/qml/components/AppInformation.qml
@@ -8,10 +8,11 @@ MouseArea {
     property int  shrunkHeight: 500
     property var  pkg
 
-    property bool _expanded: false
+    property bool _expanded: !_expansionEnabled
+    property bool _expansionEnabled: enableExpansion && content.implicitHeight > shrunkHeight
 
     clip: true
-    enabled: enableExpansion
+    enabled: _expansionEnabled
     height: content.height + (dots.visible ? dots.height : 0)
     width: parent.width
     propagateComposedEvents: true
@@ -21,7 +22,7 @@ MouseArea {
 
     Column {
         id: content
-        height: !enableExpansion || _expanded || shrunkHeight > implicitHeight ? implicitHeight : shrunkHeight
+        height: (!_expansionEnabled || _expanded) ? implicitHeight : shrunkHeight - dots.height
         anchors {
             left: parent.left
             right: parent.right
@@ -46,7 +47,6 @@ MouseArea {
 
         Item {
             id: spacer
-            visible: _expanded
             height: Theme.paddingMedium
         }
 
@@ -99,12 +99,12 @@ MouseArea {
         anchors.right: parent.right
         anchors.rightMargin: Theme.horizontalPageMargin
         source: "image://theme/icon-lock-more"
-        visible: !_expanded && enableExpansion
+        visible: !_expanded
     }
 
     OpacityRampEffect {
         sourceItem: content
-        enabled: !_expanded && enableExpansion
+        enabled: !_expanded
         direction: OpacityRamp.TopToBottom
     }
 }

--- a/qml/components/AppSummary.qml
+++ b/qml/components/AppSummary.qml
@@ -1,0 +1,75 @@
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import org.chum 1.0
+import "."
+
+Item {
+    id: item
+
+    property ChumPackage pkg
+
+    anchors {
+      left: parent.left
+      leftMargin: Theme.horizontalPageMargin
+      right: parent.right
+      rightMargin: Theme.horizontalPageMargin
+    }
+    height: Math.max(info.height, stickers.height)
+
+    Column {
+        id: info
+        anchors {
+            left: item.left
+            right: stickers.left
+            rightMargin: Theme.paddingLarge
+            verticalCenter: item.verticalCenter
+        }
+
+        ImageLabel {
+            image: pkg.updateAvailable ?
+                       "image://theme/icon-s-update" :
+                       "image://theme/icon-s-installed"
+            label: {
+                if (pkg.updateAvailable)
+                    //% "Update available"
+                    return qsTrId("chum-pkg-update-available");
+                if (pkg.installed)
+                    //% "Installed"
+                    return qsTrId("chum-pkg-installed");
+                return "";
+            }
+            visible: label
+            width: parent.width
+        }
+
+        ChumDetailItem {
+          id: categories
+          //% "Categories"
+          label: qsTrId("chum-pkg-categories")
+          value: pkg.categories.join(" ")
+          visible: value
+        }
+    }
+
+    Row {
+        id: stickers
+        anchors {
+          right: parent.right
+          rightMargin: Theme.horizontalPageMargin
+          verticalCenter: item.verticalCenter
+        }
+        spacing: Theme.paddingLarge
+
+        ImageLabel {
+            image: "image://theme/icon-s-favorite"
+            label: pkg.starsCount
+            visible: pkg.starsCount >= 0
+        }
+
+        ImageLabel {
+            image: "image://theme/icon-s-developer"
+            label: pkg.forksCount
+            visible: pkg.forksCount >= 0
+        }
+    }
+}

--- a/qml/components/AppSummary.qml
+++ b/qml/components/AppSummary.qml
@@ -24,6 +24,7 @@ Item {
             rightMargin: Theme.paddingLarge
             verticalCenter: item.verticalCenter
         }
+        spacing: Theme.paddingSmall
 
         ImageLabel {
             image: pkg.updateAvailable ?
@@ -42,6 +43,23 @@ Item {
             width: parent.width
         }
 
+        ImageLabel {
+            image: pkg.type === ChumPackage.PackageApplicationDesktop ?
+                       "image://theme/icon-s-sailfish" :
+                       "image://theme/icon-s-clipboard"
+            label: {
+                if (pkg.type === ChumPackage.PackageApplicationDesktop)
+                    //% "Sailfish application"
+                    return qsTrId("chum-pkg-type-desktop");
+                if (pkg.type === ChumPackage.PackageApplicationConsole)
+                    //% "Console application"
+                    return qsTrId("chum-pkg-type-console");
+                return ""; // will hide other types
+            }
+            visible: label
+            width: parent.width
+        }
+
         ChumDetailItem {
           id: categories
           //% "Categories"
@@ -55,7 +73,6 @@ Item {
         id: stickers
         anchors {
           right: parent.right
-          rightMargin: Theme.horizontalPageMargin
           verticalCenter: item.verticalCenter
         }
         spacing: Theme.paddingLarge

--- a/qml/components/FancyPageHeader.qml
+++ b/qml/components/FancyPageHeader.qml
@@ -4,24 +4,49 @@ import Sailfish.Silica 1.0
 Item {
     property alias title: header.title
     property alias description: header.description
+    property alias author: auth.text
     property alias iconSource: image.source
 
     width: parent.width
-    height: header.height
+    height: Math.max(column.height, image.height + image.anchors.topMargin)
 
-    PageHeader {
-        id: header
-        width: parent.width -
-               (image.visible ? image.width + Theme.paddingMedium : 0)
+    Column {
+        id: column
+        anchors {
+            left: parent.left
+            right: image.visible ? image.left : parent.right
+            rightMargin: image.visible ? Theme.paddingLarge : Theme.horizontalPageMargin
+        }
+
+        PageHeader {
+            id: header
+            rightMargin: 0
+            width: parent.width
+        }
+
+        Label {
+            id: auth
+            anchors {
+                left: parent.left
+                leftMargin: Theme.horizontalPageMargin
+                right: parent.right
+            }
+            color: Theme.secondaryHighlightColor
+            font.pixelSize: Theme.fontSizeSmall
+            horizontalAlignment: implicitWidth < width ? Text.AlignRight : Text.AlignLeft
+            truncationMode: TruncationMode.Fade
+            visible: text
+        }
     }
 
     Image {
         id: image
         visible: source.toString()
         anchors {
-            verticalCenter: header.verticalCenter
+            top: parent.top
+            topMargin: Theme.horizontalPageMargin + Theme.paddingMedium
             right: parent.right
-            rightMargin: Theme.paddingMedium
+            rightMargin: Theme.horizontalPageMargin
         }
         width: Theme.iconSizeLauncher
         height: Theme.iconSizeLauncher

--- a/qml/components/ImageLabel.qml
+++ b/qml/components/ImageLabel.qml
@@ -3,13 +3,13 @@ import Sailfish.Silica 1.0
 
 Item {
     id: item
-    height: Math.max(imageUi.implicitHeight, labelUi.implicitHeight)
-    width: childrenRect.width
+    height: visible ? Math.max(imageUi.implicitHeight, labelUi.implicitHeight) : 0
+    width: visible ? imageUi.width + labelUi.anchors.leftMargin + labelUi.implicitWidth : 0
 
-    property alias textColor: labelUi.color
+    property alias fontSize: labelUi.font.pixelSize
     property alias image: imageUi.source
     property alias label: labelUi.text
-    property alias fontSize: labelUi.font.pixelSize
+    property alias textColor: labelUi.color
 
     Image {
         id: imageUi
@@ -24,5 +24,6 @@ Item {
         anchors.verticalCenter: item.verticalCenter
         color: Theme.highlightColor
         font.pixelSize: Theme.fontSizeSmall
+        truncationMode: TruncationMode.Fade
     }
 }

--- a/qml/pages/MainPage.qml
+++ b/qml/pages/MainPage.qml
@@ -72,7 +72,9 @@ Page {
           : qsTrId("chum-no-updates")
         visible: !Chum.busy
         onClicked: pageStack.push(Qt.resolvedUrl("PackagesListPage.qml"), {
-                                      subTitle: updatesNotification.summary,
+                                      subTitleAll: updatesNotification.summary,
+                                      //% "%: applications"
+                                      subTitleApp: qsTrId("chum-updates-apps", updatesNotification.summary),
                                       updatesOnly: true
                                     })
       }
@@ -81,8 +83,10 @@ Page {
         text: qsTrId("chum-available-packages")
         visible: !Chum.busy
         onClicked: pageStack.push(Qt.resolvedUrl("PackagesListPage.qml"), {
-                                    //% "Available packages"
-                                    subTitle: qsTrId("chum-available-packages")
+                                      //% "Available packages"
+                                      subTitleAll: qsTrId("chum-available-packages"),
+                                      //% "Available applications"
+                                      subTitleApp: qsTrId("chum-available-apps")
                                   })
       }
 
@@ -95,8 +99,10 @@ Page {
           : qsTrId("chum-no-installed")
         visible: !Chum.busy
         onClicked: pageStack.push(Qt.resolvedUrl("PackagesListPage.qml"), {
-                                      //% "Installed"
-                                      subTitle: qsTrId("chum-installed"),
+                                      //% "Installed packages"
+                                      subTitleAll: qsTrId("chum-installed-packages"),
+                                      //% "Installed applications"
+                                      subTitleApp: qsTrId("chum-installed-apps"),
                                       installedOnly: true
                                     })
       }

--- a/qml/pages/MainPage.qml
+++ b/qml/pages/MainPage.qml
@@ -80,13 +80,15 @@ Page {
       }
 
       MainPageButton {
-        text: qsTrId("chum-available-packages")
+        text: Chum.showAppsByDefault ? qsTrId("chum-available-apps") :
+                                       qsTrId("chum-available-packages")
         visible: !Chum.busy
         onClicked: pageStack.push(Qt.resolvedUrl("PackagesListPage.qml"), {
                                       //% "Available packages"
                                       subTitleAll: qsTrId("chum-available-packages"),
                                       //% "Available applications"
-                                      subTitleApp: qsTrId("chum-available-apps")
+                                      subTitleApp: qsTrId("chum-available-apps"),
+                                      applicationsOnly: Chum.showAppsByDefault
                                   })
       }
 

--- a/qml/pages/MainPage.qml
+++ b/qml/pages/MainPage.qml
@@ -73,8 +73,8 @@ Page {
         visible: !Chum.busy
         onClicked: pageStack.push(Qt.resolvedUrl("PackagesListPage.qml"), {
                                       subTitleAll: updatesNotification.summary,
-                                      //% "%: applications"
-                                      subTitleApp: qsTrId("chum-updates-apps", updatesNotification.summary),
+                                      //% "Updates, applications only"
+                                      subTitleApp: qsTrId("chum-updates-apps"),
                                       updatesOnly: true
                                     })
       }

--- a/qml/pages/MainPage.qml
+++ b/qml/pages/MainPage.qml
@@ -72,7 +72,8 @@ Page {
           : qsTrId("chum-no-updates")
         visible: !Chum.busy
         onClicked: pageStack.push(Qt.resolvedUrl("PackagesListPage.qml"), {
-                                      subTitleAll: updatesNotification.summary,
+                                      //% "Updates"
+                                      subTitleAll: qsTrId("chum-updates-all"),
                                       //% "Updates, applications only"
                                       subTitleApp: qsTrId("chum-updates-apps"),
                                       updatesOnly: true

--- a/qml/pages/MainPage.qml
+++ b/qml/pages/MainPage.qml
@@ -85,6 +85,21 @@ Page {
                                     subTitle: qsTrId("chum-available-packages")
                                   })
       }
+
+      MainPageButton {
+        enabled: Chum.installedCount > 0
+        text: enabled
+          //% "Installed packages"
+          ? qsTrId("chum-installed-packages-no")
+          //% "No packages installed"
+          : qsTrId("chum-no-installed")
+        visible: !Chum.busy
+        onClicked: pageStack.push(Qt.resolvedUrl("PackagesListPage.qml"), {
+                                      //% "Installed"
+                                      subTitle: qsTrId("chum-installed"),
+                                      installedOnly: true
+                                    })
+      }
     }
   }
 }

--- a/qml/pages/PackagePage.qml
+++ b/qml/pages/PackagePage.qml
@@ -68,6 +68,7 @@ Page {
       }
 
       Row {
+          id: stickers
           anchors {
             right: parent.right
             rightMargin: Theme.horizontalPageMargin
@@ -88,6 +89,7 @@ Page {
       }
 
       ChumDetailItem {
+        id: categories
         //% "Categories"
         label: qsTrId("chum-pkg-categories")
         value: pkg.categories.join(" ")
@@ -98,7 +100,12 @@ Page {
 
       AppInformation {
         pkg: page.pkg
-        shrunkHeight: page.height/4
+        shrunkHeight: Math.max(page.height/4, page.height - (y - content.y + content.spacing +
+                                                             (screenshots.visible ? (screenshots.height+content.spacing) : 0) +
+                                                             (btnReleases.visible ? btnReleases.implicitHeight : 0) +
+                                                             (btnIssues.visible ? btnIssues.implicitHeight : 0) +
+                                                             (btnReleases.visible || btnIssues.visible ? content.spacing : 0) +
+                                                             (btnDonate.visible ? (btnDonate.height+content.spacing) : 0)))
         enableExpansion: screenshots.visible || btnDonate.visible || btnReleases.visible || btnIssues.visible
       }
 

--- a/qml/pages/PackagePage.qml
+++ b/qml/pages/PackagePage.qml
@@ -57,13 +57,8 @@ Page {
       FancyPageHeader {
         id: header
         title: pkg.name
-        description: {
-            if (pkg.summary && pkg.developer)
-                return "%1\n%2".arg(pkg.summary).arg(pkg.developer);
-            if (pkg.developer) return pkg.developer;
-            if (pkg.summary) return pkg.summary;
-            return "";
-        }
+        author: pkg.developer
+        description: pkg.summary
         iconSource: pkg.icon
       }
 

--- a/qml/pages/PackagePage.qml
+++ b/qml/pages/PackagePage.qml
@@ -38,8 +38,14 @@ Page {
           : qsTrId("chum-install")
         visible: !pkg.installed || pkg.updateAvailable
         onClicked: pkg.installed
-          ? Chum.updatePackage(pkg.pkid)
-          : Chum.installPackage(pkg.pkid)
+          ? Chum.updatePackage(pkg.id)
+          : Chum.installPackage(pkg.id)
+      }
+      MenuItem {
+        //% "Uninstall"
+        text: qsTrId("chum-uninstall")
+        visible: pkg.installed
+        onClicked: Chum.uninstallPackage(pkg.id)
       }
     }
 

--- a/qml/pages/PackagePage.qml
+++ b/qml/pages/PackagePage.qml
@@ -67,35 +67,8 @@ Page {
         iconSource: pkg.icon
       }
 
-      Row {
-          id: stickers
-          anchors {
-            right: parent.right
-            rightMargin: Theme.horizontalPageMargin
-          }
-          spacing: Theme.paddingLarge
-
-          ImageLabel {
-              image: "image://theme/icon-m-favorite"
-              label: pkg.starsCount
-              visible: pkg.starsCount >= 0
-          }
-
-          ImageLabel {
-              image: "image://theme/icon-m-shuffle"
-              label: pkg.forksCount
-              visible: pkg.forksCount >= 0
-          }
-      }
-
-      ChumDetailItem {
-        id: categories
-        //% "Categories"
-        label: qsTrId("chum-pkg-categories")
-        value: pkg.categories.join(" ")
-        visible: value
-        anchors.leftMargin: Theme.horizontalPageMargin
-        anchors.rightMargin: Theme.horizontalPageMargin
+      AppSummary {
+          pkg: page.pkg
       }
 
       AppInformation {

--- a/qml/pages/PackagesListPage.qml
+++ b/qml/pages/PackagesListPage.qml
@@ -3,7 +3,8 @@ import Sailfish.Silica 1.0
 import org.chum 1.0
 
 Page {
-  property string subTitle
+  property string subTitleAll // shown when all packages are listed
+  property string subTitleApp // shown when apps only are listed
   property string search
   property alias  applicationsOnly: chumModel.filterApplicationsOnly
   property alias  installedOnly: chumModel.filterInstalledOnly
@@ -22,7 +23,7 @@ Page {
 
         PageHeader {
             title: "Chum"
-            description: subTitle
+            description: applicationsOnly ? subTitleApp : subTitleAll
         }
 
         SearchField {

--- a/qml/pages/PackagesListPage.qml
+++ b/qml/pages/PackagesListPage.qml
@@ -40,7 +40,26 @@ Page {
     currentIndex: -1
 
     delegate: ListItem {
-      height: Theme.itemSizeMedium
+      contentHeight: Theme.itemSizeMedium
+
+      menu: ContextMenu {
+          MenuItem {
+              //% "Update"
+              text: qsTrId("chum-update")
+              onClicked: Chum.updatePackage(model.packageId)
+              visible: model.packageUpdateAvailable
+          }
+          MenuItem {
+              text: model.packageInstalled ?
+                        //% "Uninstall"
+                        qsTrId("chum-uninstall") :
+                        //% "Install"
+                        qsTrId("chum-install")
+              onClicked: model.packageInstalled ?
+                             Chum.uninstallPackage(model.packageId) :
+                             Chum.installPackage(model.packageId)
+          }
+      }
 
       onClicked: pageStack.push(Qt.resolvedUrl("../pages/PackagePage.qml"), {
         pkg:    Chum.package(model.packageId)

--- a/qml/pages/PackagesListPage.qml
+++ b/qml/pages/PackagesListPage.qml
@@ -5,6 +5,7 @@ import org.chum 1.0
 Page {
   property string subTitle
   property string search
+  property alias  applicationsOnly: chumModel.filterApplicationsOnly
   property alias  installedOnly: chumModel.filterInstalledOnly
   property alias  updatesOnly: chumModel.filterUpdatesOnly
 
@@ -61,6 +62,18 @@ Page {
     model: ChumPackagesModel {
       id: chumModel
       search: page.search
+    }
+
+    PullDownMenu {
+      busy: Chum.busy
+      MenuItem {
+        text: page.applicationsOnly ?
+              //% "Show all packages"
+              qsTrId("chum-packages-list-show-all") :
+              //% "Show applications only"
+              qsTrId("chum-packages-list-show-apps")
+        onClicked: page.applicationsOnly = !page.applicationsOnly
+      }
     }
 
     VerticalScrollDecorator {}

--- a/qml/pages/PackagesListPage.qml
+++ b/qml/pages/PackagesListPage.qml
@@ -5,6 +5,7 @@ import org.chum 1.0
 Page {
   property string subTitle
   property string search
+  property alias  installedOnly: chumModel.filterInstalledOnly
   property alias  updatesOnly: chumModel.filterUpdatesOnly
 
   id: page

--- a/qml/pages/PackagesListPage.qml
+++ b/qml/pages/PackagesListPage.qml
@@ -87,6 +87,12 @@ Page {
     PullDownMenu {
       busy: Chum.busy
       MenuItem {
+        //% "Apply all updates"
+        text: qsTrId("chum-packages-list-apply-all-updates")
+        onClicked: Chum.updateAllPackages()
+        visible: page.updatesOnly
+      }
+      MenuItem {
         text: page.applicationsOnly ?
               //% "Show all packages"
               qsTrId("chum-packages-list-show-all") :

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -44,6 +44,16 @@ Page {
             }
 
             TextSwitch {
+                checked: Chum.showAppsByDefault
+                //% "When listing available software, show only applications by default. This is a default setting and, in each listing, "
+                //% "you can switch between showing only applications or all packages using pulley menu."
+                description: qsTrId("chum-settings-show-apps-description")
+                //% "Show applications only by default"
+                text: qsTrId("chum-settings-show-apps")
+                onClicked: Chum.showAppsByDefault = !Chum.showAppsByDefault
+            }
+
+            TextSwitch {
                 automaticCheck: false
                 busy: Chum.busy
                 checked: Chum.repoTesting
@@ -52,7 +62,6 @@ Page {
                 description: qsTrId("chum-settings-testing-description")
                 //% "Use testing repository"
                 text: qsTrId("chum-settings-testing")
-
                 onClicked: Chum.repoTesting = !Chum.repoTesting;
             }
         }

--- a/qml/sailfishos-chum-gui.qml
+++ b/qml/sailfishos-chum-gui.qml
@@ -16,6 +16,10 @@ ApplicationWindow {
       //: %1 - package name, %2 - package version
       //% "%1 %2 installed"
       return QT_TRID_NOOP("chum-package-installed")
+    case Chum.PackageRemove:
+      //: %1 - package name, %2 - package version
+      //% "%1 %2 uninstalled"
+      return QT_TRID_NOOP("chum-package-uninstalled")
     case Chum.PackageUpdate:
       //: %1 - package name, %2 - package version
       //% "%1 %2 updated"

--- a/src/chum.cpp
+++ b/src/chum.cpp
@@ -272,7 +272,7 @@ void Chum::refreshRepo(bool force) {
   auto pktr = Daemon::repoSetData(
     m_ssu.repoName(),
     QStringLiteral("refresh-now"),
-    QVariant::fromValue(force).toString()
+    QVariant::fromValue(true).toString()
   );
   connect(pktr, &Transaction::finished, this, [this]() {
     SET_STATUS(QStringLiteral());

--- a/src/chum.h
+++ b/src/chum.h
@@ -13,11 +13,12 @@ class Transaction;
 
 class Chum : public QObject {
   Q_OBJECT
-  Q_PROPERTY(bool    busy READ busy NOTIFY busyChanged)
-  Q_PROPERTY(bool    repoAvailable READ repoAvailable NOTIFY repoUpdated)
-  Q_PROPERTY(bool    repoManaged READ repoManaged NOTIFY repoUpdated)
-  Q_PROPERTY(bool    repoTesting READ repoTesting WRITE setRepoTesting NOTIFY repoUpdated)
-  Q_PROPERTY(QString status READ status NOTIFY statusChanged)
+  Q_PROPERTY(bool    busy           READ busy NOTIFY busyChanged)
+  Q_PROPERTY(quint32 installedCount READ installedCount NOTIFY installedCountChanged)
+  Q_PROPERTY(bool    repoAvailable  READ repoAvailable NOTIFY repoUpdated)
+  Q_PROPERTY(bool    repoManaged    READ repoManaged NOTIFY repoUpdated)
+  Q_PROPERTY(bool    repoTesting    READ repoTesting WRITE setRepoTesting NOTIFY repoUpdated)
+  Q_PROPERTY(QString status         READ status NOTIFY statusChanged)
   Q_PROPERTY(quint32 updatesCount   READ updatesCount NOTIFY updatesCountChanged)
 
 public:
@@ -29,6 +30,7 @@ public:
   Q_ENUM(PackageOperation)
 
   bool    busy() const { return m_busy; }
+  quint32 installedCount() const { return m_installed_count; }
   bool    repoAvailable() const { return m_ssu.repoAvailable(); }
   bool    repoManaged() const { return m_ssu.manageRepo(); }
   bool    repoTesting() const { return m_ssu.repoTesting(); }
@@ -51,6 +53,7 @@ public slots:
 
 signals:
   void busyChanged();
+  void installedCountChanged();
   void error(QString errorTxt);
   void errorFatal(QString errorTitle, QString errorTxt);
   void statusChanged();
@@ -81,6 +84,7 @@ private:
   Ssu           m_ssu;
   bool          m_busy{false};
   QString       m_status;
+  quint32       m_installed_count{0};
   quint32       m_updates_count{0};
 
   QHash<QString, ChumPackage*> m_packages;

--- a/src/chum.h
+++ b/src/chum.h
@@ -49,6 +49,7 @@ public slots:
   void getUpdates(bool force = false);
   void refreshRepo(bool force = false);
   void installPackage(const QString &id);
+  void uninstallPackage(const QString &id);
   void updatePackage(const QString &id);
 
 signals:

--- a/src/chum.h
+++ b/src/chum.h
@@ -18,6 +18,7 @@ class Chum : public QObject {
   Q_PROPERTY(bool    repoAvailable  READ repoAvailable NOTIFY repoUpdated)
   Q_PROPERTY(bool    repoManaged    READ repoManaged NOTIFY repoUpdated)
   Q_PROPERTY(bool    repoTesting    READ repoTesting WRITE setRepoTesting NOTIFY repoUpdated)
+  Q_PROPERTY(bool    showAppsByDefault READ showAppsByDefault WRITE setShowAppsByDefault NOTIFY showAppsByDefaultChanged)
   Q_PROPERTY(QString status         READ status NOTIFY statusChanged)
   Q_PROPERTY(quint32 updatesCount   READ updatesCount NOTIFY updatesCountChanged)
 
@@ -34,10 +35,12 @@ public:
   bool    repoAvailable() const { return m_ssu.repoAvailable(); }
   bool    repoManaged() const { return m_ssu.manageRepo(); }
   bool    repoTesting() const { return m_ssu.repoTesting(); }
+  bool    showAppsByDefault() const { return m_show_apps_by_default; };
   QString status() const { return m_status; }
   quint32 updatesCount() const { return m_updates_count; }
 
   void    setRepoTesting(bool testing);
+  void    setShowAppsByDefault(bool v);
 
   QList<ChumPackage*> packages() const { return m_packages.values(); }
   Q_INVOKABLE ChumPackage* package(const QString &id) const { return m_packages.value(id, nullptr); }
@@ -64,6 +67,7 @@ signals:
   void packageOperationFinished(PackageOperation operation, const QString &name, const QString &version);
   void repoUpdated(); // signal ssu properties change
   void repositoryRefreshed();
+  void showAppsByDefaultChanged();
 
 private:
   explicit Chum(QObject *parent = nullptr);
@@ -87,6 +91,7 @@ private:
   QString       m_status;
   quint32       m_installed_count{0};
   quint32       m_updates_count{0};
+  bool          m_show_apps_by_default{false};
 
   QHash<QString, ChumPackage*> m_packages;
   QSet<QString>                m_packages_last_refresh;

--- a/src/chum.h
+++ b/src/chum.h
@@ -54,6 +54,7 @@ public slots:
   void installPackage(const QString &id);
   void uninstallPackage(const QString &id);
   void updatePackage(const QString &id);
+  void updateAllPackages();
 
 signals:
   void busyChanged();

--- a/src/chum.h
+++ b/src/chum.h
@@ -85,6 +85,7 @@ private:
   void refreshInstalledVersion();
 
   void startOperation(PackageKit::Transaction *pktr, const QString &pkg_id);
+  void setStatus(QString status);
 
 private:
   Ssu           m_ssu;

--- a/src/chum.h
+++ b/src/chum.h
@@ -26,6 +26,7 @@ public:
   enum PackageOperation {
     PackageUnknownOperation,
     PackageInstallation,
+    PackageRemove,
     PackageUpdate,
   };
   Q_ENUM(PackageOperation)

--- a/src/chumpackage.cpp
+++ b/src/chumpackage.cpp
@@ -202,6 +202,7 @@ void ChumPackage::setInstalledVersion(const QString &v)
   if (v == m_installed_version) return;
   m_installed_version = v;
   emit updated(m_id, PackageInstalledVersionRole);
+  emit updated(m_id, PackageInstalledRole);
 }
 
 void ChumPackage::setDeveloperLogin(const QString &login) {

--- a/src/chumpackage.cpp
+++ b/src/chumpackage.cpp
@@ -163,10 +163,16 @@ void ChumPackage::setDetails(const PackageKit::Details &v) {
 
   // Parse metadata
   QJsonObject json{QJsonDocument::fromJson(metainjson).object()};
+
   m_name = json.value("PackageName").toString(m_name);
-  m_type = json.value("Type").toString(m_id.startsWith(QStringLiteral("harbour-")) ?
-                                                         QStringLiteral("desktop-application") :
-                                                         QStringLiteral("generic"));
+
+  QString typestr = json.value("Type").toString(m_id.startsWith(QStringLiteral("harbour-")) ?
+                                                  QStringLiteral("desktop-application") :
+                                                  QStringLiteral("generic"));
+  if (typestr == QStringLiteral("desktop-application")) m_type = PackageApplicationDesktop;
+  else if (typestr == QStringLiteral("console-application")) m_type = PackageApplicationConsole;
+  else m_type = PackageGeneric;
+
   m_developer_name = json.value("DeveloperName").toString();
   m_categories = json.value("Categories").toVariant().toStringList();
   if (m_categories.isEmpty()) m_categories.push_back("Other");

--- a/src/chumpackage.cpp
+++ b/src/chumpackage.cpp
@@ -83,13 +83,12 @@ LoadableObject* ChumPackage::releases() {
   return m_releases;
 }
 
-void ChumPackage::setPkid(const QString &pkid) {
-  if (m_pkid == pkid) return;
+void ChumPackage::setPkidLatest(const QString &pkid) {
+  if (m_pkid_latest == pkid) return;
 
-  m_pkid = pkid;
-  emit pkidChanged();
+  m_pkid_latest = pkid;
 
-  if (m_pkid.isEmpty()) {
+  if (m_pkid_latest.isEmpty()) {
     m_details_update = false;
     m_installed_update = false;
     return;
@@ -116,7 +115,7 @@ void ChumPackage::setDetails(const PackageKit::Details &v) {
   m_size        = v.size();
 
   // derive name
-  m_name = Daemon::packageName(m_pkid);
+  m_name = Daemon::packageName(m_pkid_latest);
   for (const QLatin1String &prefix: {QLatin1String("harbour-"), QLatin1String("openrepos-")})
     if (m_name.startsWith(prefix))
       m_name = m_name.mid(prefix.size());
@@ -143,7 +142,7 @@ void ChumPackage::setDetails(const PackageKit::Details &v) {
   try {
       metayaml = YAML::Load(descLines.last().toStdString());
   } catch(const YAML::ParserException &e) {
-      qWarning() << "Invalid Chum section for" << m_pkid;
+      qWarning() << "Invalid Chum section for" << m_pkid_latest;
   }
 
   if (!metayaml.IsNull() && metayaml.size() > 0) {
@@ -196,9 +195,15 @@ void ChumPackage::setDetails(const PackageKit::Details &v) {
   emit updated(m_id, PackageRefreshRole);
 }
 
+void ChumPackage::setPkidInstalled(const QString &pkid) {
+  m_installed_update = false;
+  if (m_pkid_installed == pkid) return;
+  m_pkid_installed = pkid;
+  setInstalledVersion(Daemon::packageVersion(pkid));
+}
+
 void ChumPackage::setInstalledVersion(const QString &v)
 {
-  m_installed_update = false;
   if (v == m_installed_version) return;
   m_installed_version = v;
   emit updated(m_id, PackageInstalledVersionRole);

--- a/src/chumpackage.cpp
+++ b/src/chumpackage.cpp
@@ -90,12 +90,10 @@ void ChumPackage::setPkidLatest(const QString &pkid) {
 
   if (m_pkid_latest.isEmpty()) {
     m_details_update = false;
-    m_installed_update = false;
     return;
   }
 
   m_details_update = true;
-  m_installed_update = true;
 }
 
 void ChumPackage::setUpdateAvailable(bool up) {
@@ -195,8 +193,11 @@ void ChumPackage::setDetails(const PackageKit::Details &v) {
   emit updated(m_id, PackageRefreshRole);
 }
 
+void ChumPackage::clearInstalled() {
+  setPkidInstalled(QString{});
+}
+
 void ChumPackage::setPkidInstalled(const QString &pkid) {
-  m_installed_update = false;
   if (m_pkid_installed == pkid) return;
   m_pkid_installed = pkid;
   setInstalledVersion(Daemon::packageVersion(pkid));

--- a/src/chumpackage.h
+++ b/src/chumpackage.h
@@ -70,7 +70,6 @@ public:
   QString pkidLatest() const { return m_pkid_latest; }
   QString pkidInstalled() const { return m_pkid_installed; }
   bool detailsNeedsUpdate() const { return m_details_update; }
-  bool installedVersionNeedsUpdate() const { return m_installed_update; }
 
   QString availableVersion() const { return m_available_version; }
   QStringList categories() const { return m_categories; }
@@ -102,6 +101,7 @@ public:
   void setPkidInstalled(const QString &pkid);
   void setUpdateAvailable(bool up);
   void setDetails(const PackageKit::Details &v);
+  void clearInstalled();
 
   void setDeveloperLogin(const QString &login);
   void setDeveloperName(const QString &name);
@@ -134,7 +134,6 @@ private:
   QString     m_installed_version;
   bool        m_update_available{false};
   bool        m_details_update{false};
-  bool        m_installed_update{false};
 
   QString     m_available_version;
   QStringList m_categories;

--- a/src/chumpackage.h
+++ b/src/chumpackage.h
@@ -31,7 +31,7 @@ class ChumPackage : public QObject {
   Q_PROPERTY(qulonglong size        READ size         NOTIFY updated)
   Q_PROPERTY(int        starsCount  READ starsCount   NOTIFY updated)
   Q_PROPERTY(QString    summary     READ summary      NOTIFY updated)
-  Q_PROPERTY(QString    type        READ type         NOTIFY updated)
+  Q_PROPERTY(PackageType type       READ type         NOTIFY updated)
   Q_PROPERTY(bool       updateAvailable READ updateAvailable NOTIFY updated)
   Q_PROPERTY(QString    url         READ url          NOTIFY updated)
   Q_PROPERTY(QString    urlForum    READ urlForum     NOTIFY updated)
@@ -57,6 +57,13 @@ public:
     PackageOtherRole,
     PackageRefreshRole // used for updates of many parameters
   };
+
+  enum PackageType {
+    PackageApplicationDesktop,
+    PackageApplicationConsole,
+    PackageGeneric
+  };
+  Q_ENUM(PackageType)
 
   ChumPackage(QObject *parent = nullptr);
   ChumPackage(const QString &id, QObject *parent = nullptr);
@@ -91,7 +98,7 @@ public:
   qulonglong size() const { return m_size; }
   int     starsCount() const { return m_stars_count; }
   QString summary() const { return m_summary; }
-  QString type() const { return m_type; }
+  PackageType type() const { return m_type; }
   bool    updateAvailable() const { return m_update_available; }
   QString url() const { return m_url; }
   QString urlForum() const { return m_url_forum; }
@@ -153,7 +160,7 @@ private:
   qulonglong  m_size{0};
   int         m_stars_count{-1};
   QString     m_summary;
-  QString     m_type;
+  PackageType m_type;
   QString     m_url;
   QString     m_url_forum;
   QString     m_url_issues;

--- a/src/chumpackage.h
+++ b/src/chumpackage.h
@@ -9,8 +9,7 @@
 class ChumPackage : public QObject {
   Q_OBJECT
 
-  Q_PROPERTY(QString id READ id NOTIFY pkidChanged)
-  Q_PROPERTY(QString pkid READ pkid NOTIFY pkidChanged)
+  Q_PROPERTY(QString id READ id NOTIFY idChanged)
 
   Q_PROPERTY(QString    availableVersion READ availableVersion NOTIFY updated)
   Q_PROPERTY(QStringList categories READ categories   NOTIFY updated)
@@ -68,7 +67,8 @@ public:
   Q_INVOKABLE LoadableObject* releases();
 
   QString id() const { return m_id; }
-  QString pkid() const { return m_pkid; }
+  QString pkidLatest() const { return m_pkid_latest; }
+  QString pkidInstalled() const { return m_pkid_installed; }
   bool detailsNeedsUpdate() const { return m_details_update; }
   bool installedVersionNeedsUpdate() const { return m_installed_update; }
 
@@ -98,10 +98,10 @@ public:
   QString urlForum() const { return m_url_forum; }
   QString urlIssues() const { return m_url_issues; }
 
-  void setPkid(const QString &pkid);
+  void setPkidLatest(const QString &pkid);
+  void setPkidInstalled(const QString &pkid);
   void setUpdateAvailable(bool up);
   void setDetails(const PackageKit::Details &v);
-  void setInstalledVersion(const QString &v);
 
   void setDeveloperLogin(const QString &login);
   void setDeveloperName(const QString &name);
@@ -114,9 +114,12 @@ public:
   void setUrlIssues(const QString &url);
 
 signals:
+  void idChanged();
   void updated(QString packageId, Role role);
-  void pkidChanged();
   void updateAvailableChanged();
+
+private:
+  void setInstalledVersion(const QString &v);
 
 private:
   ProjectAbstract *m_project{nullptr};
@@ -126,7 +129,8 @@ private:
   LoadableObject  *m_releases{nullptr};
 
   QString     m_id; // ID of the package as used in Chum
-  QString     m_pkid; // Package ID as set by PackageKit
+  QString     m_pkid_latest; // Package ID as set by PackageKit
+  QString     m_pkid_installed; // Package ID as set by PackageKit
   QString     m_installed_version;
   bool        m_update_available{false};
   bool        m_details_update{false};

--- a/src/chumpackagesmodel.cpp
+++ b/src/chumpackagesmodel.cpp
@@ -36,6 +36,8 @@ QVariant ChumPackagesModel::data(const QModelIndex &index, int role) const {
     return p->starsCount();
   case ChumPackage::PackageTypeRole:
     return p->type();
+  case ChumPackage::PackageUpdateAvailableRole:
+    return p->updateAvailable();
   default:
     return QVariant{};
   }

--- a/src/chumpackagesmodel.cpp
+++ b/src/chumpackagesmodel.cpp
@@ -62,6 +62,8 @@ void ChumPackagesModel::reset() {
   for (ChumPackage* p: Chum::instance()->packages()) {
     disconnect(p, nullptr, this, nullptr);
     // apply filters, such as category, updatable, search query
+    if (m_filter_installed_only && !p->installed())
+      continue;
     if (m_filter_updates_only && !p->updateAvailable())
       continue;
     if (!m_search.isEmpty()) {
@@ -140,6 +142,8 @@ void ChumPackagesModel::updatePackage(QString packageId, ChumPackage::Role role)
   bool filter_or_order_may_change = false;
   if (!m_search.isEmpty() && search_roles.contains(role))
     filter_or_order_may_change = true;
+  if (m_filter_installed_only && role == ChumPackage::PackageInstalledRole)
+    filter_or_order_may_change = true;
   if (m_filter_updates_only && role == ChumPackage::PackageUpdateAvailableRole)
     filter_or_order_may_change = true;
   // TODO: other filters
@@ -162,6 +166,12 @@ void ChumPackagesModel::updatePackage(QString packageId, ChumPackage::Role role)
 void ChumPackagesModel::setFilterUpdatesOnly(bool filter) {
   m_filter_updates_only = filter;
   emit filterUpdatesOnlyChanged();
+  reset();
+}
+
+void ChumPackagesModel::setFilterInstalledOnly(bool filter) {
+  m_filter_installed_only = filter;
+  emit filterInstalledOnlyChanged();
   reset();
 }
 

--- a/src/chumpackagesmodel.cpp
+++ b/src/chumpackagesmodel.cpp
@@ -105,8 +105,6 @@ void ChumPackagesModel::reset() {
   for (const ChumPackage* p: packages)
     m_packages.push_back(p->id());
 
-  qDebug() << "Packages in the list:" << m_packages.length() << "Search:" << m_search;
-
   endResetModel();
 }
 

--- a/src/chumpackagesmodel.cpp
+++ b/src/chumpackagesmodel.cpp
@@ -34,6 +34,8 @@ QVariant ChumPackagesModel::data(const QModelIndex &index, int role) const {
     return p->name();
   case ChumPackage::PackageStarsCountRole:
     return p->starsCount();
+  case ChumPackage::PackageTypeRole:
+    return p->type();
   default:
     return QVariant{};
   }
@@ -47,6 +49,7 @@ QHash<int, QByteArray> ChumPackagesModel::roleNames() const {
     {ChumPackage::PackageInstalledVersionRole,  QByteArrayLiteral("packageInstalledVersion")},
     {ChumPackage::PackageNameRole,     QByteArrayLiteral("packageName")},
     {ChumPackage::PackageStarsCountRole, QByteArrayLiteral("packageStarsCount")},
+    {ChumPackage::PackageTypeRole, QByteArrayLiteral("packageType")},
     {ChumPackage::PackageUpdateAvailableRole,  QByteArrayLiteral("packageUpdateAvailable")},
   };
 }
@@ -62,6 +65,10 @@ void ChumPackagesModel::reset() {
   for (ChumPackage* p: Chum::instance()->packages()) {
     disconnect(p, nullptr, this, nullptr);
     // apply filters, such as category, updatable, search query
+    if (m_filter_applications_only &&
+        p->type()!=ChumPackage::PackageApplicationConsole &&
+        p->type()!=ChumPackage::PackageApplicationDesktop)
+      continue;
     if (m_filter_installed_only && !p->installed())
       continue;
     if (m_filter_updates_only && !p->updateAvailable())
@@ -109,6 +116,7 @@ void ChumPackagesModel::updatePackage(QString packageId, ChumPackage::Role role)
     ChumPackage::PackageIdRole,
     ChumPackage::PackageNameRole,
     ChumPackage::PackageStarsCountRole,
+    ChumPackage::PackageTypeRole,
     ChumPackage::PackageInstalledRole,
     ChumPackage::PackageInstalledVersionRole,
     ChumPackage::PackageUpdateAvailableRole
@@ -142,6 +150,8 @@ void ChumPackagesModel::updatePackage(QString packageId, ChumPackage::Role role)
   bool filter_or_order_may_change = false;
   if (!m_search.isEmpty() && search_roles.contains(role))
     filter_or_order_may_change = true;
+  if (m_filter_applications_only && role == ChumPackage::PackageTypeRole)
+    filter_or_order_may_change = true;
   if (m_filter_installed_only && role == ChumPackage::PackageInstalledRole)
     filter_or_order_may_change = true;
   if (m_filter_updates_only && role == ChumPackage::PackageUpdateAvailableRole)
@@ -163,15 +173,21 @@ void ChumPackagesModel::updatePackage(QString packageId, ChumPackage::Role role)
   dataChanged(index(i), index(i) ); // just refresh whole row to simplify processing here
 }
 
-void ChumPackagesModel::setFilterUpdatesOnly(bool filter) {
-  m_filter_updates_only = filter;
-  emit filterUpdatesOnlyChanged();
+void ChumPackagesModel::setFilterApplicationsOnly(bool filter) {
+  m_filter_applications_only = filter;
+  emit filterApplicationsOnlyChanged();
   reset();
 }
 
 void ChumPackagesModel::setFilterInstalledOnly(bool filter) {
   m_filter_installed_only = filter;
   emit filterInstalledOnlyChanged();
+  reset();
+}
+
+void ChumPackagesModel::setFilterUpdatesOnly(bool filter) {
+  m_filter_updates_only = filter;
+  emit filterUpdatesOnlyChanged();
   reset();
 }
 

--- a/src/chumpackagesmodel.h
+++ b/src/chumpackagesmodel.h
@@ -13,6 +13,7 @@ class ChumPackagesModel
   Q_OBJECT
   Q_INTERFACES(QQmlParserStatus)
 
+  Q_PROPERTY(bool    filterApplicationsOnly READ filterApplicationsOnly WRITE setFilterApplicationsOnly NOTIFY filterApplicationsOnlyChanged)
   Q_PROPERTY(bool    filterInstalledOnly READ filterInstalledOnly WRITE setFilterInstalledOnly NOTIFY filterInstalledOnlyChanged)
   Q_PROPERTY(bool    filterUpdatesOnly READ filterUpdatesOnly WRITE setFilterUpdatesOnly NOTIFY filterUpdatesOnlyChanged)
   Q_PROPERTY(QString search READ search WRITE setSearch NOTIFY searchChanged)
@@ -20,10 +21,12 @@ class ChumPackagesModel
 public:
   explicit ChumPackagesModel(QObject *parent = nullptr);
 
+  bool filterApplicationsOnly() const { return m_filter_applications_only; }
   bool filterInstalledOnly() const { return m_filter_installed_only; }
   bool filterUpdatesOnly() const { return m_filter_updates_only; }
   QString search() const { return m_search; }
 
+  void setFilterApplicationsOnly(bool filter);
   void setFilterInstalledOnly(bool filter);
   void setFilterUpdatesOnly(bool filter);
   void setSearch(QString search);
@@ -38,8 +41,9 @@ public:
   void componentComplete() override { m_postpone_loading=false; reset(); }
 
 signals:
-  void filterUpdatesOnlyChanged();
+  void filterApplicationsOnlyChanged();
   void filterInstalledOnlyChanged();
+  void filterUpdatesOnlyChanged();
   void searchChanged();
 
 private:
@@ -49,6 +53,7 @@ private:
   QList<QString> m_packages;
   bool           m_postpone_loading{true};
 
+  bool m_filter_applications_only{false};
   bool m_filter_installed_only{false};
   bool m_filter_updates_only{false};
   QString m_search;

--- a/src/chumpackagesmodel.h
+++ b/src/chumpackagesmodel.h
@@ -13,15 +13,18 @@ class ChumPackagesModel
   Q_OBJECT
   Q_INTERFACES(QQmlParserStatus)
 
+  Q_PROPERTY(bool    filterInstalledOnly READ filterInstalledOnly WRITE setFilterInstalledOnly NOTIFY filterInstalledOnlyChanged)
   Q_PROPERTY(bool    filterUpdatesOnly READ filterUpdatesOnly WRITE setFilterUpdatesOnly NOTIFY filterUpdatesOnlyChanged)
   Q_PROPERTY(QString search READ search WRITE setSearch NOTIFY searchChanged)
 
 public:
   explicit ChumPackagesModel(QObject *parent = nullptr);
 
+  bool filterInstalledOnly() const { return m_filter_installed_only; }
   bool filterUpdatesOnly() const { return m_filter_updates_only; }
   QString search() const { return m_search; }
 
+  void setFilterInstalledOnly(bool filter);
   void setFilterUpdatesOnly(bool filter);
   void setSearch(QString search);
 
@@ -36,6 +39,7 @@ public:
 
 signals:
   void filterUpdatesOnlyChanged();
+  void filterInstalledOnlyChanged();
   void searchChanged();
 
 private:
@@ -45,6 +49,7 @@ private:
   QList<QString> m_packages;
   bool           m_postpone_loading{true};
 
+  bool m_filter_installed_only{false};
   bool m_filter_updates_only{false};
   QString m_search;
 };

--- a/src/projectgithub.cpp
+++ b/src/projectgithub.cpp
@@ -73,8 +73,6 @@ ProjectGitHub::ProjectGitHub(const QString &url, ChumPackage *package) : Project
     return;
   }
 
-  qDebug() << "Github" << m_org << m_repo;
-
   // settings that can be set from knowing repo url
   m_package->setDeveloperLogin(m_org);
   // url is not set as it can be different homepage that is retrieved from query

--- a/src/projectgitlab.cpp
+++ b/src/projectgitlab.cpp
@@ -74,8 +74,6 @@ ProjectGitLab::ProjectGitLab(const QString &url, ChumPackage *package) : Project
     return;
   }
 
-  qDebug() << "GitLab" << m_path;
-
   // url is not set as it can be different homepage that is retrieved from query
   m_package->setUrlIssues(QStringLiteral("https://gitlab.com/%1/-/issues").arg(m_path));
 

--- a/translations/sailfishos-chum-gui.ts
+++ b/translations/sailfishos-chum-gui.ts
@@ -10,7 +10,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-search">
-        <location filename="../qml/pages/PackagesListPage.qml" line="31"/>
+        <location filename="../qml/pages/PackagesListPage.qml" line="32"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,6 +48,24 @@
         <location filename="../qml/pages/MainPage.qml" line="54"/>
         <source>Refresh repository</source>
         <oldsource>Refresh cache</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="chum-installed-packages-no" numerus="yes">
+        <location filename="../qml/pages/MainPage.qml" line="93"/>
+        <source>Installed packages: %n</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message id="chum-no-installed">
+        <location filename="../qml/pages/MainPage.qml" line="95"/>
+        <source>No packages installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="chum-installed">
+        <location filename="../qml/pages/MainPage.qml" line="99"/>
+        <source>Installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-no-updates">
@@ -107,33 +125,33 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-check-updates">
-        <location filename="../src/chum.cpp" line="217"/>
+        <location filename="../src/chum.cpp" line="224"/>
         <source>Check for updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-refresh-repository-impossible">
-        <location filename="../src/chum.cpp" line="253"/>
+        <location filename="../src/chum.cpp" line="260"/>
         <source>Cannot refresh repository as it is not available</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-refresh-repository">
-        <location filename="../src/chum.cpp" line="263"/>
+        <location filename="../src/chum.cpp" line="270"/>
         <source>Refreshing Chum repository</source>
         <oldsource>Refresh Chum repository</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-refresh-repository-failed">
-        <location filename="../src/chum.cpp" line="279"/>
+        <location filename="../src/chum.cpp" line="286"/>
         <source>Failed to refresh Chum repository</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-repo-management-disabled-title">
-        <location filename="../src/chum.cpp" line="288"/>
+        <location filename="../src/chum.cpp" line="295"/>
         <source>Repositories misconfigured</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-repo-management-disabled-txt">
-        <location filename="../src/chum.cpp" line="294"/>
+        <location filename="../src/chum.cpp" line="301"/>
         <source>Cannot manage Chum repositories through GUI. You probably have multiple Chum repositories defined in SSU or Chum repository disabled. For listing repositories and their removal, use &apos;ssu&apos; command in terminal.
 
 Please remove all defined Chum repositories and restart GUI. GUI will add missing Chum repository if needed on restart.</source>
@@ -143,28 +161,28 @@ Please remove all defined Chum repositories and restart GUI. GUI will add missin
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-repo-management-disabled">
-        <location filename="../src/chum.cpp" line="309"/>
+        <location filename="../src/chum.cpp" line="316"/>
         <source></source>
         <oldsource>Cannot manage Chum repositories through GUI</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-add-repo">
-        <location filename="../src/chum.cpp" line="300"/>
+        <location filename="../src/chum.cpp" line="307"/>
         <source>Adding Chum repository</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-setup-repo">
-        <location filename="../src/chum.cpp" line="317"/>
+        <location filename="../src/chum.cpp" line="324"/>
         <source>Setting up Chum repository</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-install-package">
-        <location filename="../src/chum.cpp" line="328"/>
+        <location filename="../src/chum.cpp" line="335"/>
         <source>Install package</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-update-package">
-        <location filename="../src/chum.cpp" line="337"/>
+        <location filename="../src/chum.cpp" line="344"/>
         <source>Update package</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/sailfishos-chum-gui.ts
+++ b/translations/sailfishos-chum-gui.ts
@@ -50,13 +50,11 @@
         <oldsource>Refresh cache</oldsource>
         <translation type="unfinished"></translation>
     </message>
-    <message id="chum-installed-packages-no" numerus="yes">
+    <message id="chum-installed-packages-no">
         <location filename="../qml/pages/MainPage.qml" line="93"/>
-        <source>Installed packages: %n</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
+        <source>Installed packages</source>
+        <oldsource>Installed packages: %n</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="chum-no-installed">
         <location filename="../qml/pages/MainPage.qml" line="95"/>
@@ -84,8 +82,13 @@
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="chum-uninstall">
+        <location filename="../qml/pages/PackagePage.qml" line="46"/>
+        <source>Uninstall</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="chum-pkg-categories">
-        <location filename="../qml/pages/PackagePage.qml" line="86"/>
+        <location filename="../qml/pages/PackagePage.qml" line="92"/>
         <source>Categories</source>
         <translation type="unfinished"></translation>
     </message>
@@ -181,8 +184,13 @@ Please remove all defined Chum repositories and restart GUI. GUI will add missin
         <source>Install package</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="chum-update-package">
+    <message id="chum-uninstall-package">
         <location filename="../src/chum.cpp" line="344"/>
+        <source>Uninstall package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="chum-update-package">
+        <location filename="../src/chum.cpp" line="353"/>
         <source>Update package</source>
         <translation type="unfinished"></translation>
     </message>
@@ -268,7 +276,11 @@ Please remove all defined Chum repositories and restart GUI. GUI will add missin
         <translation type="unfinished"></translation>
     </message>
     <message>
+<<<<<<< HEAD
         <location filename="../qml/pages/PackagePage.qml" line="133"/>
+=======
+        <location filename="../qml/pages/PackagePage.qml" line="185"/>
+>>>>>>> 328efbe (Add support for package removal)
         <source>Make Dontation</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/sailfishos-chum-gui.ts
+++ b/translations/sailfishos-chum-gui.ts
@@ -44,16 +44,27 @@
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="chum-settings-title">
+        <location filename="../qml/pages/MainPage.qml" line="47"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="21"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="chum-refresh-cache">
         <location filename="../qml/pages/MainPage.qml" line="54"/>
         <source>Refresh repository</source>
         <oldsource>Refresh cache</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="chum-no-updates">
+        <location filename="../qml/pages/MainPage.qml" line="72"/>
+        <source>No updates available</source>
+        <oldsource>No update available</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="chum-installed-packages-no">
         <location filename="../qml/pages/MainPage.qml" line="93"/>
         <source>Installed packages</source>
-        <oldsource>Installed packages: %n</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-no-installed">
@@ -64,12 +75,6 @@
     <message id="chum-installed">
         <location filename="../qml/pages/MainPage.qml" line="99"/>
         <source>Installed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="chum-no-updates">
-        <location filename="../qml/pages/MainPage.qml" line="72"/>
-        <source>No updates available</source>
-        <oldsource>No update available</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-update">
@@ -93,12 +98,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-releases-number">
-        <location filename="../qml/pages/PackagePage.qml" line="111"/>
+        <location filename="../qml/pages/PackagePage.qml" line="117"/>
         <source>Releases (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-issues-number">
-        <location filename="../qml/pages/PackagePage.qml" line="122"/>
+        <location filename="../qml/pages/PackagePage.qml" line="128"/>
         <source>Issues (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -140,7 +145,7 @@
     <message id="chum-refresh-repository">
         <location filename="../src/chum.cpp" line="270"/>
         <source>Refreshing Chum repository</source>
-        <oldsource>Refresh Chum repository</oldsource>
+        <oldsource>Refresh repositories</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-refresh-repository-failed">
@@ -158,20 +163,16 @@
         <source>Cannot manage Chum repositories through GUI. You probably have multiple Chum repositories defined in SSU or Chum repository disabled. For listing repositories and their removal, use &apos;ssu&apos; command in terminal.
 
 Please remove all defined Chum repositories and restart GUI. GUI will add missing Chum repository if needed on restart.</source>
-        <oldsource>Cannot manage Chum repositories through GUI. You probably have multiple Chum repositories defined in SSU or Chum repository disabled.
-
-Please remove all defined Chum repositories and restart GUI. GUI will add missing Chum repository if needed on restart.</oldsource>
-        <translation type="unfinished"></translation>
-    </message>
-    <message id="chum-repo-management-disabled">
-        <location filename="../src/chum.cpp" line="316"/>
-        <source></source>
-        <oldsource>Cannot manage Chum repositories through GUI</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-add-repo">
         <location filename="../src/chum.cpp" line="307"/>
         <source>Adding Chum repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="chum-repo-management-disabled">
+        <location filename="../src/chum.cpp" line="316"/>
+        <source></source>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-setup-repo">
@@ -213,7 +214,6 @@ Please remove all defined Chum repositories and restart GUI. GUI will add missin
     <message id="chum-issue-with-number">
         <location filename="../qml/pages/IssuePage.qml" line="35"/>
         <source>Issue: #%1</source>
-        <oldsource>Issue: %1</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-issue">
@@ -257,6 +257,31 @@ Please remove all defined Chum repositories and restart GUI. GUI will add missin
         <source>Link</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="chum-settings-status-repo-management-failed">
+        <location filename="../qml/pages/SettingsPage.qml" line="35"/>
+        <source>Chum repository management failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="chum-settings-status-repo-available">
+        <location filename="../qml/pages/SettingsPage.qml" line="39"/>
+        <source>Current status: Chum repository available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="chum-settings-status-repo-not-available">
+        <location filename="../qml/pages/SettingsPage.qml" line="41"/>
+        <source>Current status: Chum repository is not available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="chum-settings-testing-description">
+        <location filename="../qml/pages/SettingsPage.qml" line="52"/>
+        <source>Use testing version of Chum repository. This is mainly useful for developers for testing their packages before publishing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="chum-settings-testing">
+        <location filename="../qml/pages/SettingsPage.qml" line="54"/>
+        <source>Use testing repository</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PackagePage</name>
@@ -276,11 +301,7 @@ Please remove all defined Chum repositories and restart GUI. GUI will add missin
         <translation type="unfinished"></translation>
     </message>
     <message>
-<<<<<<< HEAD
-        <location filename="../qml/pages/PackagePage.qml" line="133"/>
-=======
-        <location filename="../qml/pages/PackagePage.qml" line="185"/>
->>>>>>> 328efbe (Add support for package removal)
+        <location filename="../qml/pages/PackagePage.qml" line="139"/>
         <source>Make Dontation</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
This is on top of #31 - should be reviewed after that.

Fixes: #22 #23 #24 #36 #37

On top of these fixes, it has slightly revised packagepage that should use available space better (calculates available area to show description in shrunk form) and shifts categories/installation status next to stars/forks info (through dedicated item appsummary.qml).