### PR TITLE
Revise token injection and add multiple Gitlab providers support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# sailfishos-chum-gui
+# SailfishOS Chum GUI
 
 A client app for the Chum repositories.

--- a/rpm/sailfishos-chum-gui.spec
+++ b/rpm/sailfishos-chum-gui.spec
@@ -22,7 +22,16 @@ BuildRequires:  PackageKit-Qt5-devel
 BuildRequires:  qt5-qttools-linguist
 
 %description
-A client app for the Chum repositories
+A client app for the Chum repositories.
+
+PackageName: Chum GUI
+Type: desktop-application
+Categories:
+  - System
+  - Utility
+Custom:
+  Repo: https://github.com/sailfishos-chum/sailfishos-chum-gui
+Icon: https://raw.githubusercontent.com/sailfishos-chum/sailfishos-chum-gui/main/icons/sailfishos-chum-gui.svg
 
 %prep
 %setup -q -n %{name}-%{version}

--- a/rpm/sailfishos-chum-gui.spec
+++ b/rpm/sailfishos-chum-gui.spec
@@ -28,9 +28,10 @@ A client app for the Chum repositories
 %setup -q -n %{name}-%{version}
 
 %build
+
 %cmake -DCHUMGUI_VERSION=%(echo %{version} | grep -Eo '^[0-9]+(\.[0-9]+)*') \
-       -DGITHUB_TOKEN=%(cat token-github.txt)  \
-       -DGITLAB_TOKEN=%(cat token-gitlab.txt)  \
+       -DGITHUB_TOKEN=%(cat %{SOURCE1})  \
+       -DGITLAB_TOKEN=%(cat %{SOURCE2})  \
      .
 cmake --build .
 

--- a/src/projectgitlab.cpp
+++ b/src/projectgitlab.cpp
@@ -63,12 +63,12 @@ void ProjectGitLab::initSites() {
   if (!s_sites.isEmpty()) return;
   for (const QString &sitetoken: QStringLiteral(GITLAB_TOKEN).split(QChar('|'))) {
       QStringList st = sitetoken.split(QChar(':'));
-      qDebug() << "GL:" << st << sitetoken;
       if (st.size() != 2) {
           qWarning() << "Error parsing provided GitLab site-token pairs";
           return;
       }
       s_sites[st[0]] = st[1];
+      qDebug() << "GitLab support added for" << st[0];
   }
 }
 

--- a/src/projectgitlab.cpp
+++ b/src/projectgitlab.cpp
@@ -15,8 +15,7 @@
 #include <QVariantList>
 #include <QVariantMap>
 
-static QString reqAuth{QStringLiteral("Bearer " GITLAB_TOKEN)};
-static QString reqUrl{QStringLiteral("https://gitlab.com/api/graphql")};
+QMap<QString, QString> ProjectGitLab::s_sites;
 
 //////////////////////////////////////////////////////
 /// helper functions
@@ -30,51 +29,66 @@ static QString getName(const QVariant &v) {
   return QStringLiteral("%1 (%2)").arg(name, login);
 }
 
-static QNetworkReply* sendQuery(const QString &query) {
-  QNetworkRequest request;
-  request.setUrl(reqUrl);
-  request.setRawHeader("Content-Type", "application/json");
-  request.setRawHeader("Authorization", reqAuth.toLocal8Bit());
-  return nMng->post(request, query.toLocal8Bit());
-}
-
-static bool parseUrl(const QString &u, QString &path) {
+static void parseUrl(const QString &u, QString &h, QString &path) {
   QUrl url(u);
-  QString host = url.host();
+  h = url.host();
   QString p = url.path();
   if (p.startsWith('/')) p = p.mid(1);
   if (p.endsWith('/')) p.chop(1);
-
-  if (host != QStringLiteral("gitlab.com"))
-    return false;
-
   path = p;
-  return true;
 }
 
 //////////////////////////////////////////////////////
 /// ProjectGitLab
 
 ProjectGitLab::ProjectGitLab(const QString &url, ChumPackage *package) : ProjectAbstract(package) {
-  bool ok = parseUrl(url, m_path);
-  if (!ok) {
+  initSites();
+  parseUrl(url, m_host, m_path);
+  if (!s_sites.contains(m_host)) {
     qWarning() << "Shouldn't happen: ProjectGitLab initialized with incorrect service" << url;
     return;
   }
 
+  m_token = s_sites.value(m_host, QString{});
+
   // url is not set as it can be different homepage that is retrieved from query
-  m_package->setUrlIssues(QStringLiteral("https://gitlab.com/%1/-/issues").arg(m_path));
+  m_package->setUrlIssues(QStringLiteral("https://%1/%2/-/issues").arg(m_host, m_path));
 
   // fetch information from GitLab
   fetchRepoInfo();
 }
 
 // static
-bool ProjectGitLab::isProject(const QString &url) {
-  QString p;
-  return parseUrl(url, p);
+void ProjectGitLab::initSites() {
+  if (!s_sites.isEmpty()) return;
+  for (const QString &sitetoken: QStringLiteral(GITLAB_TOKEN).split(QChar('|'))) {
+      QStringList st = sitetoken.split(QChar(':'));
+      qDebug() << "GL:" << st << sitetoken;
+      if (st.size() != 2) {
+          qWarning() << "Error parsing provided GitLab site-token pairs";
+          return;
+      }
+      s_sites[st[0]] = st[1];
+  }
 }
 
+// static
+bool ProjectGitLab::isProject(const QString &url) {
+  initSites();
+  QString h, p;
+  parseUrl(url, h, p);
+  return s_sites.contains(h);
+}
+
+QNetworkReply* ProjectGitLab::sendQuery(const QString &query) {
+  QString reqAuth = QStringLiteral("Bearer %1").arg(m_token);
+  QString reqUrl = QStringLiteral("https://%1/api/graphql").arg(m_host);
+  QNetworkRequest request;
+  request.setUrl(reqUrl);
+  request.setRawHeader("Content-Type", "application/json");
+  request.setRawHeader("Authorization", reqAuth.toLocal8Bit());
+  return nMng->post(request, query.toLocal8Bit());
+}
 
 void ProjectGitLab::fetchRepoInfo() {
   QString query = QStringLiteral(R"(

--- a/src/projectgitlab.h
+++ b/src/projectgitlab.h
@@ -2,6 +2,7 @@
 #define PROJECTGITLAB_H
 
 #include <QObject>
+#include <QNetworkReply>
 #include <QString>
 
 #include "projectabstract.h"
@@ -22,11 +23,17 @@ public:
 signals:
 
 private:
+  QNetworkReply* sendQuery(const QString &query);
   void fetchRepoInfo();
 
-private:
-  QString m_path;
+  static void initSites();
 
+private:
+  QString m_host;
+  QString m_path;
+  QString m_token;
+
+  static QMap<QString, QString> s_sites;
 };
 
 #endif // PROJECTGITLAB_H


### PR DESCRIPTION
Tokens are now expected to be in `rpm` subfolder or in the main folder for OBS.

GitLab tokens are given in a format

```
"site1:token1|site2:token2|...|siteN:tokenN"
```

If a single site is given, `"` are not needed.

In addition, Chum section was added to RPM SPEC and README title was adjusted.

Fixes #39 

