### PR TITLE
Add libraries to the list of packages

### DIFF
--- a/qml/pages/CategoriesPage.qml
+++ b/qml/pages/CategoriesPage.qml
@@ -70,6 +70,11 @@ Page {
             categoryIds: "Graphics"
         }
         ListElement {
+            //% "Libraries"
+            category: qsTrId("chum-category-libraries")
+            categoryIds: "Library"
+        }
+        ListElement {
             //% "Location and Navigation"
             category: qsTrId("chum-category-maps")
             categoryIds: "Maps"

--- a/src/chum.cpp
+++ b/src/chum.cpp
@@ -108,8 +108,8 @@ void Chum::refreshPackages() {
           [[maybe_unused]] const QString &summary
           ) {
     QString pn = Daemon::packageName(packageID);
-    if (pn.endsWith(QStringLiteral("-debuginfo")) ||
-        pn.endsWith(QStringLiteral("-debugsource")) )
+    if (pn.endsWith(QLatin1String("-debuginfo")) ||
+        pn.endsWith(QLatin1String("-debugsource")) )
       return;
     QString pd = Daemon::packageData(packageID);
     if (pd == m_ssu.repoName())

--- a/src/chum.cpp
+++ b/src/chum.cpp
@@ -99,7 +99,7 @@ void Chum::refreshPackages() {
   m_packages_last_refresh.clear();
   m_packages_last_refresh_installed.clear();
 
-  auto pktr = Daemon::getPackages(Transaction::FilterNotDevel);
+  auto pktr = Daemon::getPackages(Transaction::FilterNotSource);
   //% "Get list of packages"
   setStatus(qtTrId("chum-get-list-packages"));
   connect(pktr, &Transaction::package,  this, [this](
@@ -107,6 +107,10 @@ void Chum::refreshPackages() {
           const QString &packageID,
           [[maybe_unused]] const QString &summary
           ) {
+    QString pn = Daemon::packageName(packageID);
+    if (pn.endsWith(QStringLiteral("-debuginfo")) ||
+        pn.endsWith(QStringLiteral("-debugsource")) )
+      return;
     QString pd = Daemon::packageData(packageID);
     if (pd == m_ssu.repoName())
       m_packages_last_refresh.insert(packageID);

--- a/src/chumpackage.cpp
+++ b/src/chumpackage.cpp
@@ -113,10 +113,13 @@ void ChumPackage::setDetails(const PackageKit::Details &v) {
   m_size        = v.size();
 
   // derive name
-  m_name = Daemon::packageName(m_pkid_latest);
+  QString pname = Daemon::packageName(m_pkid_latest);
+  m_name = pname;
   for (const QLatin1String &prefix: {QLatin1String("harbour-"), QLatin1String("openrepos-")})
     if (m_name.startsWith(prefix))
       m_name = m_name.mid(prefix.size());
+  if (m_name.endsWith(QStringLiteral("-devel")))
+    m_name = m_name.left(m_name.size() - 6 /*sizeof -devel*/) + QStringLiteral("-development");
   bool capitalize = true;
   const QChar sep{'-'};
   const QChar space{' '};
@@ -175,7 +178,9 @@ void ChumPackage::setDetails(const PackageKit::Details &v) {
 
   m_developer_name = json.value("DeveloperName").toString();
   m_categories = json.value("Categories").toVariant().toStringList();
-  if (m_categories.isEmpty()) m_categories.push_back("Other");
+  if (pname.endsWith(QStringLiteral("-devel")))
+    m_categories.push_back(QStringLiteral("Library"));
+  if (m_categories.isEmpty()) m_categories.push_back(QStringLiteral("Other"));
 
   m_repo_type = json.value("Custom").toObject().value("RepoType").toString();
   m_repo_url = json.value("Custom").toObject().value("Repo").toString();

--- a/src/chumpackage.cpp
+++ b/src/chumpackage.cpp
@@ -118,7 +118,7 @@ void ChumPackage::setDetails(const PackageKit::Details &v) {
   for (const QLatin1String &prefix: {QLatin1String("harbour-"), QLatin1String("openrepos-")})
     if (m_name.startsWith(prefix))
       m_name = m_name.mid(prefix.size());
-  if (m_name.endsWith(QStringLiteral("-devel")))
+  if (m_name.endsWith(QLatin1String("-devel")))
     m_name = m_name.left(m_name.size() - 6 /*sizeof -devel*/) + QStringLiteral("-development");
   bool capitalize = true;
   const QChar sep{'-'};


### PR DESCRIPTION
Chum has a large selection of libraries and it is an information that is useful for developers. With this PR, all -devel packages are included into the list when packages are listed. For category, I have added "Library" as "Development" is for development applications (https://specifications.freedesktop.org/menu-spec/latest/apa.html). Debug packages are filtered out as they don't add much for normal usage of Chum GUI.

Please review