### PR TITLE
Sort packages in case-insensitive manner

### DIFF
--- a/src/chumpackagesmodel.cpp
+++ b/src/chumpackagesmodel.cpp
@@ -107,7 +107,7 @@ void ChumPackagesModel::reset() {
 
   // sort packages
   std::sort(packages.begin(), packages.end(), [](const ChumPackage *a, const ChumPackage *b){
-    return a->name() < b->name();
+    return a->name().toCaseFolded() < b->name().toCaseFolded();
   });
 
   // record the result


### PR DESCRIPTION
This will prevent packages that prefer to start form smaller letter (ownKeepass) to be relegated to the bottom of the list. Please review