### PR TITLE
Process package name to figure out if it is library

### DIFF
--- a/qml/components/AppInformation.qml
+++ b/qml/components/AppInformation.qml
@@ -62,6 +62,14 @@ MouseArea {
         }
 
         ChumDetailItem {
+            id: packageNameItem
+            //% "Package name"
+            label: qsTrId("chum-pkg-package-name")
+            value: pkg.packageName
+            visible: pkg.packageName
+        }
+
+        ChumDetailItem {
             //% "Download size"
             label: qsTrId("chum-pkg-download-size")
             value: Format.formatFileSize(pkg.size)

--- a/src/chumpackage.cpp
+++ b/src/chumpackage.cpp
@@ -114,25 +114,31 @@ void ChumPackage::setDetails(const PackageKit::Details &v) {
 
   // derive name
   QString pname = Daemon::packageName(m_pkid_latest);
-  m_name = pname;
   m_package_name = pname;
-  for (const QLatin1String &prefix: {QLatin1String("harbour-"), QLatin1String("openrepos-")})
-    if (m_name.startsWith(prefix))
-      m_name = m_name.mid(prefix.size());
-  if (m_name.endsWith(QLatin1String("-devel")))
-    m_name = m_name.left(m_name.size() - 6 /*sizeof -devel*/) + QStringLiteral("-development");
-  bool capitalize = true;
-  const QChar sep{'-'};
-  const QChar space{' '};
-  for (auto begin = m_name.begin(), end = m_name.end(), it = begin; it != end; ++it) {
-    if (capitalize) {
-      *it = it->toUpper();
-      capitalize = false;
-    } else if (it != begin && *it == sep) {
-      *it = space;
-      capitalize = true;
-    }
+  m_name = QString{};
+  QStringList nparts = pname.split('-');
+  bool is_app = false;
+  bool is_lib = false;
+  if (nparts.size() > 0) {
+     if (nparts.first() == QLatin1String("harbour")) {
+         is_app = true;
+         nparts.removeFirst();
+     } else if (nparts.first() == QLatin1String("openrepos"))
+       nparts.removeFirst();
+     else if (nparts.first().startsWith(QLatin1String("lib"))) {
+       is_lib = true;
+       nparts.first() = nparts.first().mid(3);
+       //% "Library"
+       nparts.insert(1, qtTrId("chum-desc-library"));
+     }
+     if (nparts.last() == QLatin1String("devel")) {
+       is_lib = true;
+       //% "Development"
+       nparts.last() = qtTrId("chum-desc-development");
+     }
   }
+  for (const QString& b: nparts)
+    m_name += b.left(1).toUpper() + b.mid(1).toLower() + " ";
   m_name = m_name.trimmed();
 
   // parse description
@@ -170,7 +176,7 @@ void ChumPackage::setDetails(const PackageKit::Details &v) {
 
   m_name = json.value("PackageName").toString(m_name);
 
-  QString typestr = json.value("Type").toString(m_id.startsWith(QStringLiteral("harbour-")) ?
+  QString typestr = json.value("Type").toString(is_app ?
                                                   QStringLiteral("desktop-application") :
                                                   QStringLiteral("generic"));
   if (typestr == QStringLiteral("desktop-application")) m_type = PackageApplicationDesktop;
@@ -179,7 +185,8 @@ void ChumPackage::setDetails(const PackageKit::Details &v) {
 
   m_developer_name = json.value("DeveloperName").toString();
   m_categories = json.value("Categories").toVariant().toStringList();
-  if (pname.endsWith(QStringLiteral("-devel")))
+  // guess category only if it is empty
+  if (is_lib && m_categories.isEmpty())
     m_categories.push_back(QStringLiteral("Library"));
   if (m_categories.isEmpty()) m_categories.push_back(QStringLiteral("Other"));
 

--- a/src/chumpackage.cpp
+++ b/src/chumpackage.cpp
@@ -115,6 +115,7 @@ void ChumPackage::setDetails(const PackageKit::Details &v) {
   // derive name
   QString pname = Daemon::packageName(m_pkid_latest);
   m_name = pname;
+  m_package_name = pname;
   for (const QLatin1String &prefix: {QLatin1String("harbour-"), QLatin1String("openrepos-")})
     if (m_name.startsWith(prefix))
       m_name = m_name.mid(prefix.size());

--- a/src/chumpackage.h
+++ b/src/chumpackage.h
@@ -25,6 +25,7 @@ class ChumPackage : public QObject {
   Q_PROPERTY(int        issuesCount READ issuesCount  NOTIFY updated)
   Q_PROPERTY(QString    license     READ license      NOTIFY updated)
   Q_PROPERTY(QString    name        READ name         NOTIFY updated)
+  Q_PROPERTY(QString    packageName READ packageName  NOTIFY updated)
   Q_PROPERTY(int        releasesCount READ releasesCount  NOTIFY updated)
   Q_PROPERTY(QString    repo        READ repo         NOTIFY updated)
   Q_PROPERTY(QStringList screenshots READ screenshots NOTIFY updated)
@@ -93,6 +94,7 @@ public:
   int     issuesCount() const { return m_issues_count; }
   QString license() const { return m_license; }
   QString name() const { return m_name; }
+  QString packageName() const { return m_package_name; }
   QString repo() const { return m_repo_url; }
   int     releasesCount() const { return m_releases_count; }
   QStringList screenshots() const { return m_screenshots; }
@@ -154,6 +156,7 @@ private:
   int         m_issues_count{-1};
   QString     m_license;
   QString     m_name;
+  QString     m_package_name;
   int         m_releases_count{-1};
   QString     m_repo_type;
   QString     m_repo_url;


### PR DESCRIPTION
This PR revises package name processing and adds listing original package name in package page. New approach drops "lib" from the start of the package name and sets its category to Library. Such automatic processing can be overwritten if needed by specifying `PackageName` and/or `Categories`. However, as a result of such processing, rather large fraction of Chum packages have now better name and set category.

Please review