### PR TITLE
Add packagers and packaging URL

### DIFF
--- a/qml/components/AppInformation.qml
+++ b/qml/components/AppInformation.qml
@@ -99,6 +99,18 @@ MouseArea {
 
             onLinkActivated: Qt.openUrlExternally(link)
         }
+
+        ChumDetailItem {
+            visible: !!pkg.packagingUrl
+            text: '<font color="%1">%3</font> <font color="%2"><a href="%4">%4</a></font>'
+            .arg(Theme.secondaryHighlightColor)
+            .arg(Theme.primaryColor)
+            //% "Packaging repository"
+            .arg(qsTrId("chum-pkg-packaging-link"))
+            .arg(pkg.packagingUrl)
+
+            onLinkActivated: Qt.openUrlExternally(link)
+        }
     }
 
     Image {

--- a/qml/components/AppInformation.qml
+++ b/qml/components/AppInformation.qml
@@ -7,6 +7,7 @@ MouseArea {
     property bool enableExpansion: true
     property int  shrunkHeight: 500
     property var  pkg
+    property bool developerShown: false
 
     property bool _expanded: !_expansionEnabled
     property bool _expansionEnabled: enableExpansion && content.implicitHeight > shrunkHeight
@@ -31,7 +32,6 @@ MouseArea {
         }
 
         Label {
-            id: bodyLabel
             width: parent.width
             text: pkg.description
             color: infoItem.pressed ? Theme.highlightColor : Theme.primaryColor
@@ -43,10 +43,17 @@ MouseArea {
         Item {
             id: spacer
             height: Theme.paddingLarge
+            width: parent.width
         }
 
         ChumDetailItem {
-            id: installedVersionItem
+            visible: pkg.developer && infoItem.developerShown
+            //% "Developer"
+            label: qsTrId("chum-pkg-developer")
+            value: pkg.developer
+        }
+
+        ChumDetailItem {
             visible: pkg.installed
             //% "Installed version"
             label: qsTrId("chum-pkg-installed-version")
@@ -54,7 +61,6 @@ MouseArea {
         }
 
         ChumDetailItem {
-            id: availableVersionItem
             //% "Available version"
             label: qsTrId("chum-pkg-available-version")
             value: pkg.availableVersion
@@ -62,7 +68,6 @@ MouseArea {
         }
 
         ChumDetailItem {
-            id: packageNameItem
             //% "Package name"
             label: qsTrId("chum-pkg-package-name")
             value: pkg.packageName

--- a/qml/components/FancyPageHeader.qml
+++ b/qml/components/FancyPageHeader.qml
@@ -6,6 +6,7 @@ Item {
     property alias description: header.description
     property alias author: auth.text
     property alias iconSource: image.source
+    property bool  packagerShown: false
 
     width: parent.width
     height: Math.max(column.height, image.height + image.anchors.topMargin)
@@ -22,6 +23,21 @@ Item {
             id: header
             rightMargin: 0
             width: parent.width
+        }
+
+        Label {
+            anchors {
+                left: parent.left
+                leftMargin: Theme.horizontalPageMargin
+                right: parent.right
+            }
+            color: Theme.secondaryHighlightColor
+            font.pixelSize: Theme.fontSizeSmall
+            height: visible ? implicitHeight + Theme.paddingSmall : 0
+            horizontalAlignment: implicitWidth < width ? Text.AlignRight : Text.AlignLeft
+            //% "Packaged by"
+            text: qsTrId("chum-page-header-packaged-by")
+            visible: packagerShown
         }
 
         Label {

--- a/qml/components/PackagesListItem.qml
+++ b/qml/components/PackagesListItem.qml
@@ -6,8 +6,8 @@ Item {
     id: item
 
     height: Theme.paddingLarge + Math.max(image.height,
-                                          title.height + categories.height + developer.height +
-                                          categories.anchors.topMargin + developer.anchors.topMargin)
+                                          title.height + categories.height + author.height +
+                                          categories.anchors.topMargin + author.anchors.topMargin)
     width: parent.width
 
     property bool highlighted: false
@@ -55,7 +55,7 @@ Item {
     }
 
     Label {
-        id: developer
+        id: author
         anchors.left: image.right
         anchors.leftMargin: Theme.paddingLarge
         anchors.right: stickers.left
@@ -65,7 +65,7 @@ Item {
         color: Theme.highlightColor
         font.pixelSize: Theme.fontSizeSmall
         height: visible ? implicitHeight : 0
-        text: model.packageDeveloper
+        text: model.packagePackager ?  model.packagePackager : model.packageDeveloper
         truncationMode: TruncationMode.Fade
         visible: text
     }

--- a/qml/pages/PackagePage.qml
+++ b/qml/pages/PackagePage.qml
@@ -60,9 +60,10 @@ Page {
             FancyPageHeader {
                 id: header
                 title: pkg.name
-                author: pkg.developer
+                author: pkg.packager ? pkg.packager : pkg.developer
                 description: pkg.summary
                 iconSource: pkg.icon
+                packagerShown: pkg.packager
             }
 
             AppSummary {
@@ -71,6 +72,7 @@ Page {
 
             AppInformation {
                 pkg: page.pkg
+                developerShown: header.packagerShown
                 shrunkHeight: Math.max(page.height/4, page.height - (y - content.y + content.spacing +
                                                                      (screenshots.visible ? (screenshots.height+content.spacing) : 0) +
                                                                      (btnReleases.visible ? btnReleases.implicitHeight : 0) +

--- a/src/chumpackage.cpp
+++ b/src/chumpackage.cpp
@@ -211,7 +211,7 @@ void ChumPackage::setDetails(const PackageKit::Details &v) {
     m_url_issues = json.value("Url").toObject().value("Bugtracker").toString();
     m_donation = json.value("Url").toObject().value("Donation").toString();
 
-    for (const QString &u: {m_repo_url, m_url}) {
+    for (const QString &u: {m_repo_url, m_url, m_packaging_repo_url}) {
         if (ProjectGitHub::isProject(u))
             m_project = new ProjectGitHub(u, this);
         else if (ProjectGitLab::isProject(u))

--- a/src/chumpackage.cpp
+++ b/src/chumpackage.cpp
@@ -201,6 +201,7 @@ void ChumPackage::setDetails(const PackageKit::Details &v) {
     if (m_categories.isEmpty()) m_categories.push_back(QStringLiteral("Other"));
 
     m_repo_url = json.value("Custom").toObject().value("Repo").toString();
+    m_packaging_repo_url = json.value("Custom").toObject().value("PackagingRepo").toString();
 
     m_icon = json.value("Icon").toString();
     m_screenshots = json.value("Screenshots").toVariant().toStringList();

--- a/src/chumpackage.cpp
+++ b/src/chumpackage.cpp
@@ -36,12 +36,20 @@ ChumPackage::ChumPackage(const QString &id, QObject *parent)
     m_id = id;
 }
 
-QString ChumPackage::developer() const {
-    if (!m_developer_login.isEmpty() && !m_developer_name.isEmpty())
-        return QStringLiteral("%1 (%2)").arg(m_developer_name, m_developer_login);
-    if (!m_developer_login.isEmpty()) return m_developer_login;
-    if (!m_developer_name.isEmpty()) return m_developer_name;
+static QString nameFormatting(const QString &name, const QString &login) {
+    if (!login.isEmpty() && !name.isEmpty())
+        return QStringLiteral("%1 (%2)").arg(name, login);
+    if (!login.isEmpty()) return login;
+    if (!name.isEmpty()) return name;
     return QString();
+}
+
+QString ChumPackage::developer() const {
+    return nameFormatting(m_developer_name, m_developer_login);
+}
+
+QString ChumPackage::packager() const {
+    return nameFormatting(m_packager_name, m_packager_login);
 }
 
 bool ChumPackage::installed() const {
@@ -184,13 +192,14 @@ void ChumPackage::setDetails(const PackageKit::Details &v) {
 
     m_developer_name = json.value("DeveloperName").toString();
     m_developer_name_from_spec = !m_developer_name.isEmpty();
+    m_packager_name = json.value("PackagerName").toString();
+    m_packager_name_from_spec = !m_packager_name.isEmpty();
     m_categories = json.value("Categories").toVariant().toStringList();
     // guess category only if it is empty
     if (is_lib && m_categories.isEmpty())
         m_categories.push_back(QStringLiteral("Library"));
     if (m_categories.isEmpty()) m_categories.push_back(QStringLiteral("Other"));
 
-    m_repo_type = json.value("Custom").toObject().value("RepoType").toString();
     m_repo_url = json.value("Custom").toObject().value("Repo").toString();
 
     m_icon = json.value("Icon").toString();
@@ -240,6 +249,18 @@ void ChumPackage::setDeveloperLogin(const QString &login) {
 
 void ChumPackage::setDeveloperName(const QString &name) {
     SET_IF_EMPTY(m_developer_name, PackageDeveloperRole, name);
+}
+
+void ChumPackage::setPackagerLogin(const QString &login) {
+    // If packager name was set (presumingly from SPEC) then avoid setting login separately.
+    // As login is impssible to set from SPEC separately, this prevents getting conflicting
+    // records
+    if (m_packager_name_from_spec) return;
+    SET_IF_EMPTY(m_packager_login, PackagePackagerRole, login);
+}
+
+void ChumPackage::setPackagerName(const QString &name) {
+    SET_IF_EMPTY(m_packager_name, PackagePackagerRole, name);
 }
 
 void ChumPackage::setUrl(const QString &url) {

--- a/src/chumpackage.h
+++ b/src/chumpackage.h
@@ -24,6 +24,8 @@ class ChumPackage : public QObject {
     Q_PROPERTY(QString    license     READ license      NOTIFY updated)
     Q_PROPERTY(QString    name        READ name         NOTIFY updated)
     Q_PROPERTY(QString    packageName READ packageName  NOTIFY updated)
+    Q_PROPERTY(QString    packager    READ packager     NOTIFY updated)
+    Q_PROPERTY(QString    packagingUrl READ packagingUrl NOTIFY updated)
     Q_PROPERTY(int        releasesCount READ releasesCount  NOTIFY updated)
     Q_PROPERTY(QString    repo        READ repo         NOTIFY updated)
     Q_PROPERTY(QStringList screenshots READ screenshots NOTIFY updated)
@@ -47,6 +49,7 @@ public:
         PackageInstalledRole,
         PackageInstalledVersionRole,
         PackageNameRole,
+        PackagePackagerRole,
         PackageStarsCountRole,
         PackageSummaryRole,
         PackageTypeRole,
@@ -89,6 +92,8 @@ public:
     QString license() const { return m_license; }
     QString name() const { return m_name; }
     QString packageName() const { return m_package_name; }
+    QString packager() const;
+    QString packagingUrl() const { return m_packaging_repo_url; }
     QString repo() const { return m_repo_url; }
     int     releasesCount() const { return m_releases_count; }
     QStringList screenshots() const { return m_screenshots; }
@@ -111,6 +116,8 @@ public:
     void setDeveloperName(const QString &name);
     void setForksCount(int count);
     void setIssuesCount(int count);
+    void setPackagerLogin(const QString &login);
+    void setPackagerName(const QString &name);
     void setReleasesCount(int count);
     void setStarsCount(int count);
     void setUrl(const QString &url);
@@ -152,8 +159,11 @@ private:
     QString     m_license;
     QString     m_name;
     QString     m_package_name;
+    QString     m_packager_login;
+    QString     m_packager_name;
+    bool        m_packager_name_from_spec{false};
+    QString     m_packaging_repo_url;
     int         m_releases_count{-1};
-    QString     m_repo_type;
     QString     m_repo_url;
     QStringList m_screenshots;
     qulonglong  m_size{0};

--- a/src/chumpackagesmodel.cpp
+++ b/src/chumpackagesmodel.cpp
@@ -36,6 +36,8 @@ QVariant ChumPackagesModel::data(const QModelIndex &index, int role) const {
         return p->installedVersion();
     case ChumPackage::PackageNameRole:
         return p->name();
+    case ChumPackage::PackagePackagerRole:
+        return p->packager();
     case ChumPackage::PackageStarsCountRole:
         return p->starsCount();
     case ChumPackage::PackageTypeRole:
@@ -56,6 +58,7 @@ QHash<int, QByteArray> ChumPackagesModel::roleNames() const {
         {ChumPackage::PackageInstalledRole,  QByteArrayLiteral("packageInstalled")},
         {ChumPackage::PackageInstalledVersionRole,  QByteArrayLiteral("packageInstalledVersion")},
         {ChumPackage::PackageNameRole,     QByteArrayLiteral("packageName")},
+        {ChumPackage::PackagePackagerRole,     QByteArrayLiteral("packagePackager")},
         {ChumPackage::PackageStarsCountRole, QByteArrayLiteral("packageStarsCount")},
         {ChumPackage::PackageTypeRole, QByteArrayLiteral("packageType")},
         {ChumPackage::PackageUpdateAvailableRole,  QByteArrayLiteral("packageUpdateAvailable")},
@@ -135,7 +138,8 @@ void ChumPackagesModel::updatePackage(QString packageId, ChumPackage::Role role)
                 ChumPackage::PackageSummaryRole,
                 ChumPackage::PackageCategoriesRole,
                 ChumPackage::PackageDeveloperRole,
-                ChumPackage::PackageDescriptionRole
+                ChumPackage::PackageDescriptionRole,
+                ChumPackage::PackagePackagerRole
     };
 
     QList<ChumPackage::Role> sort_roles{


### PR DESCRIPTION
This PR adds `PackagerName` and `Custom/PackagingRepo`. This allows to distinguish the packager and developer contribution which has been not clear so far. 

As discussed at FSO, if the both names are given, packager is shown in the packages list and package page top right, if given. This is to show more familiar names to the users allowing them to contact relevant person. In this case, developer is listed in the package description.

If main repo is not given, packaging repository will be used to show issues and releases. Otherwise, main repository is linked. I avoided linking the both repositories as then we will get double issues/releases links which would clatter the UI.

Please review.

Fixes #63