### PR TITLE
Spec file: Fix Chum metadata & enhance package description

### DIFF
--- a/rpm/sailfishos-chum-gui.spec
+++ b/rpm/sailfishos-chum-gui.spec
@@ -12,7 +12,9 @@ Source101:      sailfishos-chum-gui-rpmlintrc
 Requires:       sailfishsilica-qt5 >= 0.10.9
 Requires:       ssu
 Conflicts:      sailfishos-chum
+Obsoletes:      sailfishos-chum
 Conflicts:      sailfishos-chum-testing
+Obsoletes:      sailfishos-chum-testing
 Provides:       sailfishos-chum-repository
 BuildRequires:  pkgconfig(sailfishapp) >= 1.0.2
 BuildRequires:  pkgconfig(Qt5Core)

--- a/rpm/sailfishos-chum-gui.spec
+++ b/rpm/sailfishos-chum-gui.spec
@@ -1,5 +1,5 @@
 Name:           sailfishos-chum-gui
-Summary:        SailfishOS:Chum GUI
+Summary:        GUI application for utilising the SailfishOS:Chum community repository
 Version:        0.4.1
 Release:        1
 Group:          Applications/System
@@ -34,9 +34,12 @@ BuildRequires:  sed
 %endif
 
 %description
-A client app for the Chum repositories.
+SailfishOS:Chum GUI is a graphical application for managing software packages from the SailfishOS:Chum community repository.
 
-PackageName: Chum GUI
+# This description section includes the metadata for SailfishOS:Chum, see
+# https://github.com/sailfishos-chum/main/blob/main/Metadata.md
+%if "%{?vendor}" == "chum"
+PackageName: SailfishOS:Chum GUI application
 Type: desktop-application
 Categories:
   - System
@@ -44,6 +47,7 @@ Categories:
 Custom:
   Repo: https://github.com/sailfishos-chum/sailfishos-chum-gui
 Icon: https://raw.githubusercontent.com/sailfishos-chum/sailfishos-chum-gui/main/icons/sailfishos-chum-gui.svg
+%endif
 
 %prep
 %setup -q -n %{name}-%{version}

--- a/rpm/sailfishos-chum-gui.spec
+++ b/rpm/sailfishos-chum-gui.spec
@@ -11,6 +11,9 @@ Source2:        token-gitlab.txt
 Source101:      sailfishos-chum-gui-rpmlintrc
 Requires:       sailfishsilica-qt5 >= 0.10.9
 Requires:       ssu
+Conflicts:      sailfishos-chum
+Conflicts:      sailfishos-chum-testing
+Provides:       sailfishos-chum-repository
 BuildRequires:  pkgconfig(sailfishapp) >= 1.0.2
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Qml)


### PR DESCRIPTION
- Adhere to the spec file conventions for the %description field: A full sentence with a verb ending in a full stop.
- Add comment with link to the documentation for the SailfishOS:Chum metadata.
- Fill "%name", "%description" and "PackageName" fields with the terms used elsewhere: the documentation at GitHub and OpenRepos
- Fix SailfishOS:Chum metadata being displayed in the SailfishOS:Chum GUI application (this one!) due to missing %if / %endif construct.
- Add "Conflicts:" and "Provides:" as counterparts to (conflicts) respectively aligned with (provides) the [SailfishOS:Chum repo helper RPMs](https://github.com/sailfishos-chum/main/blob/main/rpm/chum.spec).