### PR TITLE
Overhaul spec file

### DIFF
--- a/rpm/sailfishos-chum-gui.changes
+++ b/rpm/sailfishos-chum-gui.changes
@@ -1,7 +1,10 @@
-* Mon Dec 27 2022 olf <Olf0@users.noreply.github.com> 0.5.1-1
+* Sun Jan 22 2023 olf <Olf0@users.noreply.github.com> - 0.5.1-1
 - Overhaul spec file
+- Create three issue-templates
+- Use build.merproject.org as SFOS-OBS' DNS-name (#133)
+- New or updated translations: DE, ES, PL, SK
 
-* Wed Mar 02 2022 Rinigus <rinigus.git@gmail.com> 0.5.0-1
+* Wed Mar 02 2022 Rinigus <rinigus.git@gmail.com> - 0.5.0-1
 - Rework strings
 - Update translations
 - Use generic type for SFOS older than 4.1
@@ -9,11 +12,11 @@
 - Fallback to tag info if release is not described at GitHub
 - Disable package operations while there is some operation running
 
-* Mon Feb 07 2022 Rinigus <rinigus.git@gmail.com> 0.4.1-1
+* Mon Feb 07 2022 Rinigus <rinigus.git@gmail.com> - 0.4.1-1
 - Update translations
 - Remove the search box focus when scrolling
 
-* Wed Jan 19 2022 Rinigus <rinigus.git@gmail.com> 0.4.0-1
+* Wed Jan 19 2022 Rinigus <rinigus.git@gmail.com> - 0.4.0-1
 - Improve compatibility with older SFOS versions
 - Allow to specify description as URL pointing to MarkDown
 - Add packagers and packaging URL
@@ -24,13 +27,13 @@
 - Bugfixes
 - Add and update translations
 
-* Sun Jan 02 2022 Rinigus <rinigus.git@gmail.com> 0.3.0-1
+* Sun Jan 02 2022 Rinigus <rinigus.git@gmail.com> - 0.3.0-1
 - Add metadata support
 - Add GitHub and GitLab integration
 - GUI updates and addition of missing elements
 - Manage Chum repositories from GUI
 
-* Thu Sep 23 2021 Petr Tsymbarovich <petr@tsymbarovich.ru> 0.2.0-1
+* Thu Sep 23 2021 Petr Tsymbarovich <petr@tsymbarovich.ru> - 0.2.0-1
 - Don't list devel packages
 - Show installed version for updates
 - Notify on updates available
@@ -39,5 +42,5 @@
 - Fix building for SFOS 3.1, 3.2
 - Add an option for manual repository refresh
 
-* Tue Sep 21 2021 Petr Tsymbarovich <petr@tsymbarovich.ru> 0.1-1
+* Tue Sep 21 2021 Petr Tsymbarovich <petr@tsymbarovich.ru> - 0.1-1
 - First public release

--- a/rpm/sailfishos-chum-gui.changes
+++ b/rpm/sailfishos-chum-gui.changes
@@ -1,3 +1,6 @@
+* Mon Dec 27 2022 olf <Olf0@users.noreply.github.com> 0.5.1-1
+- Overhaul spec file
+
 * Wed Mar 02 2022 Rinigus <rinigus.git@gmail.com> 0.5.0-1
 - Rework strings
 - Update translations

--- a/rpm/sailfishos-chum-gui.spec
+++ b/rpm/sailfishos-chum-gui.spec
@@ -31,6 +31,9 @@ BuildRequires:  sed
 # Bundle YAML library only for builds at OBS corresponding to older SFOS version targets < v4.0.0.00
 %if 0%{?sailfishos_version} && 0%{?sailfishos_version} < 40000
 %define bundle_yaml 1
+%endif
+
+%if 0%{?bundle_yaml}
 %define __provides_exclude_from ^%{_datadir}/.*$
 %define __requires_exclude ^libyaml-cpp.*$
 %endif

--- a/rpm/sailfishos-chum-gui.spec
+++ b/rpm/sailfishos-chum-gui.spec
@@ -91,7 +91,10 @@ then
   ssu rr sailfishos-chum-testing
   rm -f /var/cache/ssu/features.ini
   ssu ur
-  # Remove a %%{name}-installer log-file, if extant:
+  # Remove a %%{name}-installer log-file, if there.
+  # This is deliberately solely done when removing %%{name}, because users tend
+  # to try things until %%{name} is installed and subsequently report issues with
+  # the %%{name}-installer, hence the log file shall be still there, then.
   rm -f %{_localstatedir}/log/%{name}-installer.log.txt
 fi
 # BTW, `ssu`, `rm -f`, `mkdir -p` etc. *always* return with "0" ("success"), hence

--- a/rpm/sailfishos-chum-gui.spec
+++ b/rpm/sailfishos-chum-gui.spec
@@ -11,10 +11,9 @@ Source2:        token-gitlab.txt
 Source101:      %{name}-rpmlintrc
 Requires:       sailfishsilica-qt5 >= 0.10.9
 Requires:       ssu
+Requires(postun): ssu
 Conflicts:      sailfishos-chum
-Obsoletes:      sailfishos-chum
 Conflicts:      sailfishos-chum-testing
-Obsoletes:      sailfishos-chum-testing
 Provides:       sailfishos-chum-repository
 BuildRequires:  pkgconfig(sailfishapp) >= 1.0.2
 BuildRequires:  pkgconfig(Qt5Core)

--- a/rpm/sailfishos-chum-gui.spec
+++ b/rpm/sailfishos-chum-gui.spec
@@ -102,6 +102,10 @@ fi
 # committed on 18 February 2019 by tibbs ( https://pagure.io/user/tibbs ) as
 # "8d0cec9 Partially convert to semantic line breaks." in
 # https://pagure.io/packaging-committee/c/8d0cec97aedc9b34658d004e3a28123f36404324
+# Hence I have the impression, that only the main section of a spec file is
+# interpreted by `rpmbuild` in a shell called with the option `-e', but not the
+# scriptlets (`%pre`, `%post`, `%preun`, `%postun`, `%pretrans`, `%posttrans`,
+# `%trigger*` and `%file*`), which are also not interpreted by `rpmbuild`!
 exit 0
 
 %files

--- a/rpm/sailfishos-chum-gui.spec
+++ b/rpm/sailfishos-chum-gui.spec
@@ -11,6 +11,7 @@ Source2:        token-gitlab.txt
 Source101:      sailfishos-chum-gui-rpmlintrc
 Requires:       sailfishsilica-qt5 >= 0.10.9
 Requires:       ssu
+Requires:       ssu
 Conflicts:      sailfishos-chum
 Obsoletes:      sailfishos-chum
 Conflicts:      sailfishos-chum-testing
@@ -48,11 +49,11 @@ Categories:
   - Utility
 Custom:
   Repo: https://github.com/sailfishos-chum/sailfishos-chum-gui
-Icon: https://raw.githubusercontent.com/sailfishos-chum/sailfishos-chum-gui/main/icons/sailfishos-chum-gui.svg
+Icon: https://github.com/sailfishos-chum/sailfishos-chum-gui/raw/main/icons/sailfishos-chum-gui.svg
 %endif
 
 %prep
-%setup -q -n %{name}-%{version}
+%setup -q
 
 %build
 # SFOS RPM cmake macro disables RPATH
@@ -83,7 +84,7 @@ sed -i 's/silica-qt5/generic/' %{buildroot}%{_datadir}/applications/sailfishos-c
 %endif
 
 %postun
-if [ $1 = 0 ]  # Removal
+if [ "$1" = 0 ]  # Removal
 then
   ssu rr sailfishos-chum
   ssu rr sailfishos-chum-testing
@@ -94,9 +95,15 @@ fi
 # no appended `|| true` needed to satisfy `set -e` for failing commands outside of
 # flow control directives (if, while, until etc.).  Furthermore on Fedora Docs it
 # is indicated that solely the final exit status of a whole scriptlet is crucial: 
-# https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_syntax
+# See https://docs.pagure.org/packaging-guidelines/Packaging%3AScriptlets.html
+# or https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_syntax
+# committed on 18 February 2019 by tibbs ( https://pagure.io/user/tibbs ) as
+# "8d0cec9 Partially convert to semantic line breaks." in
+# https://pagure.io/packaging-committee/c/8d0cec97aedc9b34658d004e3a28123f36404324
+exit 0
 
 %files
+%defattr(-,root,root,-)
 %{_bindir}/%{name}
 %dir %{_datadir}/%{name}
 %{_datadir}/applications/%{name}.desktop

--- a/rpm/sailfishos-chum-gui.spec
+++ b/rpm/sailfishos-chum-gui.spec
@@ -91,6 +91,8 @@ then
   ssu rr sailfishos-chum-testing
   rm -f /var/cache/ssu/features.ini
   ssu ur
+  # Remove a %%{name}-installer log-file, if extant:
+  rm -f %{_localstatedir}/log/%{name}-installer.log.txt
 fi
 # BTW, `ssu`, `rm -f`, `mkdir -p` etc. *always* return with "0" ("success"), hence
 # no appended `|| true` needed to satisfy `set -e` for failing commands outside of

--- a/rpm/sailfishos-chum-gui.spec
+++ b/rpm/sailfishos-chum-gui.spec
@@ -28,7 +28,7 @@ BuildRequires:  PackageKit-Qt5-devel
 BuildRequires:  qt5-qttools-linguist
 BuildRequires:  sed
 
-# Bundle YAML library only for builds at OBS corresponding to older SFOS version targets < 4.0.0.00
+# Bundle YAML library only for builds at OBS corresponding to older SFOS version targets < v4.0.0.00
 %if 0%{?sailfishos_version} && 0%{?sailfishos_version} < 40000
 %define bundle_yaml 1
 %define __provides_exclude_from ^%{_datadir}/.*$
@@ -77,7 +77,7 @@ cp -a %{_libdir}/libyaml-cpp.so.* %{buildroot}%{_datadir}/%{name}/lib
 chmod -x %{buildroot}%{_datadir}/%{name}/lib/*.so*
 %endif
 
-# Rectify desktop file for old SailfishOS releases < 4.0.1.00
+# Rectify desktop file for old SailfishOS releases < v4.0.1.00
 %if 0%{?sailfishos_version} && 0%{?sailfishos_version} < 40100
 sed -i 's/silica-qt5/generic/' %{buildroot}%{_datadir}/applications/sailfishos-chum-gui.desktop
 %endif

--- a/rpm/sailfishos-chum-gui.spec
+++ b/rpm/sailfishos-chum-gui.spec
@@ -104,7 +104,7 @@ exit 0
 %files
 %defattr(-,root,root,-)
 %{_bindir}/%{name}
-%dir %{_datadir}/%{name}
+%{_datadir}/%{name}
 %{_datadir}/applications/%{name}.desktop
 %{_datadir}/icons/hicolor/*/apps/%{name}.png
 %{_datadir}/mapplauncherd/privileges.d/%{name}

--- a/rpm/sailfishos-chum-gui.spec
+++ b/rpm/sailfishos-chum-gui.spec
@@ -4,8 +4,8 @@ Version:        0.5.1
 Release:        1
 Group:          Applications/System
 License:        MIT
-URL:            https://github.com/sailfishos-chum/sailfishos-chum-gui
-Source0:        %{name}-%{version}.tar.bz2
+URL:            https://github.com/sailfishos-chum/%{name}
+Source0:        https://github.com/sailfishos-chum/%{name}/archive/%{version}/%{name}-%{version}.tar.gz
 Source1:        token-github.txt
 Source2:        token-gitlab.txt
 Source101:      %{name}-rpmlintrc
@@ -14,6 +14,7 @@ Requires:       ssu
 Requires(postun): ssu
 Conflicts:      sailfishos-chum
 Conflicts:      sailfishos-chum-testing
+Conflicts:      sailfishos-chum-gui-installer
 Provides:       sailfishos-chum-repository
 BuildRequires:  pkgconfig(sailfishapp) >= 1.0.2
 BuildRequires:  pkgconfig(Qt5Core)

--- a/rpm/sailfishos-chum-gui.spec
+++ b/rpm/sailfishos-chum-gui.spec
@@ -104,13 +104,12 @@ fi
 # is indicated that solely the final exit status of a whole scriptlet is crucial: 
 # See https://docs.pagure.org/packaging-guidelines/Packaging%3AScriptlets.html
 # or https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_syntax
-# committed on 18 February 2019 by tibbs ( https://pagure.io/user/tibbs ) as
-# "8d0cec9 Partially convert to semantic line breaks." in
+# committed on 18 February 2019 by tibbs ( https://pagure.io/user/tibbs ) in
 # https://pagure.io/packaging-committee/c/8d0cec97aedc9b34658d004e3a28123f36404324
 # Hence I have the impression, that only the main section of a spec file is
-# interpreted by `rpmbuild` in a shell called with the option `-e', but not the
-# scriptlets (`%pre`, `%post`, `%preun`, `%postun`, `%pretrans`, `%posttrans`,
-# `%trigger*` and `%file*`), which are also not interpreted by `rpmbuild`!
+# interpreted in a shell called with the option `-e', but not the scriptlets
+# (`%%pre`, `%%post`, `%%preun`, `%%postun`, `%%pretrans`, `%%posttrans`,
+# `%%trigger*` and `%%file*`).
 exit 0
 
 %files

--- a/rpm/sailfishos-chum-gui.spec
+++ b/rpm/sailfishos-chum-gui.spec
@@ -5,7 +5,7 @@ Release:        1
 Group:          Applications/System
 License:        MIT
 URL:            https://github.com/sailfishos-chum/%{name}
-Source0:        https://github.com/sailfishos-chum/%{name}/archive/%{version}/%{name}-%{version}.tar.gz
+Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz
 Source1:        token-github.txt
 Source2:        token-gitlab.txt
 Source101:      %{name}-rpmlintrc

--- a/rpm/sailfishos-chum-gui.spec
+++ b/rpm/sailfishos-chum-gui.spec
@@ -11,7 +11,6 @@ Source2:        token-gitlab.txt
 Source101:      sailfishos-chum-gui-rpmlintrc
 Requires:       sailfishsilica-qt5 >= 0.10.9
 Requires:       ssu
-Requires:       ssu
 Conflicts:      sailfishos-chum
 Obsoletes:      sailfishos-chum
 Conflicts:      sailfishos-chum-testing


### PR DESCRIPTION
* Do not try to own /usr/bin by claiming %{_bindir} in %files section.

* ~~Cease using~~ `%defattr(-,root,root,-)`, ~~which~~ does not set or alter any permissions due to twice "-" and `root:root` should be the automatically set by a recent `rpm` (v4.14 since SailfishOS 2.2.1) for files deployed to common directories.  %defattr is also mostly obsolete, see https://docs.fedoraproject.org/en-US/packaging-guidelines/#_file_permissions and https://pagure.io/packaging-committee/issue/77
  **→** Deferred for later, in order to have more time to thoroughly check that `rpm` automatically sets the correct permissions for *all* files `sailfishos-chum-gui` deploys without %defattr.  Another reason is, "not too many changes at once", even though they are trivial (because also typos are trivial (errors)).

* No `rm -rf  %{buildroot}` in %install section: This is long obsolete (just as %clean is)!  `rpm` / `rpmbuild` does both automatically since long ago.

* Only remove repositories via `ssu rr` when package is removed (not also when package is updated) in %postun section.

* Formatting: Fix / enhance indentation at multiple places.

* Increase version.

--------------------

* Append `exit 0` to %postun scriptlet for safety and clarity.

* Use shorter and simpler link to SVG icon.

* Drop `-n %{name}-%{version}` for %setup, because that always has been the default.