### PR TITLE
WIP: Implement a method of retrieving the package update time

### DIFF
--- a/qml/components/AppInformation.qml
+++ b/qml/components/AppInformation.qml
@@ -8,6 +8,7 @@ MouseArea {
     property bool enableExpansion: true
     property int  shrunkHeight: 500
     property var  pkg
+    property var  mtime
     property bool developerShown: false
 
     property bool _expanded: !_expansionEnabled
@@ -85,6 +86,13 @@ MouseArea {
             label: qsTrId("chum-pkg-package-name")
             value: pkg.packageName
             visible: pkg.packageName
+        }
+
+        ChumDetailItem {
+            //% "Package last updated:"
+            label: qsTrId("chum-pkg-package-mtime")
+            value: mtime
+            visible: mtime
         }
 
         ChumDetailItem {

--- a/qml/pages/PackagePage.qml
+++ b/qml/pages/PackagePage.qml
@@ -5,6 +5,7 @@ import "../components"
 
 Page {
     property ChumPackage pkg
+    property var mtime
 
     id: page
     allowedOrientations: Orientation.All
@@ -78,6 +79,7 @@ Page {
 
             AppInformation {
                 pkg: page.pkg
+                mtime: page.mtime
                 developerShown: header.packagerShown
                 shrunkHeight: Math.max(page.height/4, page.height - (y - content.y + content.spacing +
                                                                      (screenshots.visible ? (screenshots.height+content.spacing) : 0) +

--- a/qml/pages/PackagesListPage.qml
+++ b/qml/pages/PackagesListPage.qml
@@ -18,6 +18,13 @@ Page {
 
     allowedOrientations: Orientation.All
 
+    BusyIndicator {
+        size: BusyIndicatorSize.Large
+        anchors.centerIn: parent
+        running: chumModel.busy == true
+        visible: running
+    }
+
     SilicaListView {
         id: view
         anchors.fill: parent
@@ -78,7 +85,8 @@ Page {
             }
 
             onClicked: pageStack.push(Qt.resolvedUrl("../pages/PackagePage.qml"), {
-                                          pkg:    Chum.package(model.packageId)
+                                          pkg:    Chum.package(model.packageId),
+                                          mtime: model.packageMTime
                                       })
 
             onDownChanged: {

--- a/src/chum.h
+++ b/src/chum.h
@@ -45,6 +45,8 @@ public:
     void    setRepoTesting(bool testing);
     void    setShowAppsByDefault(bool v);
     void    setManualVersion(const QString &v);
+    QString repoName() { return m_ssu.repoName();}
+    QString repoVersion() { return m_manualVersion.isEmpty() ? m_ssu.deviceVersion() : m_manualVersion; }
 
     const QList<ChumPackage*> packages() const { return m_packages.values(); }
     Q_INVOKABLE ChumPackage* package(const QString &id) const { return m_packages.value(id, nullptr); }

--- a/src/chumpackage.h
+++ b/src/chumpackage.h
@@ -55,6 +55,7 @@ public:
         PackageSummaryRole,
         PackageTypeRole,
         PackageUpdateAvailableRole,
+        PackageMTime,
 
         PackageOtherRole,
         PackageRefreshRole // used for updates of many parameters

--- a/src/chumpackagesmodel.h
+++ b/src/chumpackagesmodel.h
@@ -3,6 +3,7 @@
 #include <QAbstractListModel>
 #include <QQmlParserStatus>
 #include <QSet>
+#include <QJsonDocument>
 
 #include "chumpackage.h"
 
@@ -18,6 +19,7 @@ class ChumPackagesModel
     Q_PROPERTY(bool    filterUpdatesOnly READ filterUpdatesOnly WRITE setFilterUpdatesOnly NOTIFY filterUpdatesOnlyChanged)
     Q_PROPERTY(QString search READ search WRITE setSearch NOTIFY searchChanged)
     Q_PROPERTY(QString showCategory READ showCategory WRITE setShowCategory NOTIFY showCategoryChanged)
+    Q_PROPERTY(bool    busy READ busy NOTIFY busyChanged)
 
 public:
     explicit ChumPackagesModel(QObject *parent = nullptr);
@@ -43,23 +45,30 @@ public:
     void classBegin() override {}
     void componentComplete() override { m_postpone_loading=false; reset(); }
 
+    bool busy() { return m_busy; }
+
 signals:
     void filterApplicationsOnlyChanged();
     void filterInstalledOnlyChanged();
     void filterUpdatesOnlyChanged();
     void searchChanged();
     void showCategoryChanged();
+    void busyChanged();
 
 private:
     void updatePackage(QString packageId, ChumPackage::Role role);
+    void getChumCache();
+    QDateTime findPackageMTime(const QString &rpm) const;
 
 private:
     QList<QString> m_packages;
     bool           m_postpone_loading{true};
+    bool           m_busy{false};
 
     bool m_filter_applications_only{false};
     bool m_filter_installed_only{false};
     bool m_filter_updates_only{false};
     QString m_search;
     QSet<QString> m_show_category;
+    QJsonDocument m_chumPackageCache;
 };

--- a/src/ssu.cpp
+++ b/src/ssu.cpp
@@ -2,6 +2,7 @@
 
 #include <QDBusPendingCall>
 #include <QDBusPendingReply>
+#include <QDBusReply>
 #include <QDebug>
 
 static QString s_repo_regular(
@@ -25,6 +26,9 @@ Ssu::Ssu(QObject *parent) :
         QDBusConnection::systemBus(),
         parent )
 {
+    QDBusReply<QString> version = call(QStringLiteral("release"), false);
+    m_device_version = version;
+    qDebug() << "Device version:" << m_device_version;
 }
 
 void Ssu::loadRepos() {

--- a/src/ssu.h
+++ b/src/ssu.h
@@ -16,6 +16,7 @@ public:
     bool repoAvailable() const { return m_manage_repo && !m_repo_name.isEmpty(); }
     bool repoTesting() const { return m_manage_repo && m_repo_testing; }
     QString repoName() const { return m_manage_repo ? m_repo_name : QString{}; }
+    QString deviceVersion() const {return m_device_version;}
 
     void loadRepos();
     void setRepo(const QString &version=QString(), bool testing=false);
@@ -30,6 +31,7 @@ private:
     bool m_manage_repo{false};
     bool m_repo_testing{false};
     QString m_repo_name;
+    QString m_device_version;
 
     QList< std::pair<QString,QString> > m_repos;
     QString m_added_repo_name;


### PR DESCRIPTION
The package update time is based on the last update of the _source_ pacakge, not the binary package.  To do this, I have a server application, currently hosted on piggz.co.uk:8081 which uses the OBS API to build a JSON model, relating projects, packages, repositories and binaries.

To find the package mtime, you iterate the model, searching for the project, then find the repository matching the current device, then look for the package in the binaries.  WHen the pacakge is found from the binary, get the mtime from the source package list.

Currently I dont know how to get the repo name from SSU, therfore the arch is hardcoded as aarch64.

Included some simple update to the QML to show the update time, nothing more complicated such as a section of "recently udpated apps"

Server code will be posted later for comment, it could certainly be improved (currently a single large cache), and Im happy for others to take this on if the idea is sound.