### PR TITLE
Add `width:` to labels with `wrapMode:` etc.

### DIFF
--- a/qml/pages/AboutPage.qml
+++ b/qml/pages/AboutPage.qml
@@ -45,15 +45,6 @@ Page {
             }
 
             Label {
-                //% "License: %1"
-                text: qsTrId("chum-about-license").arg("MIT")
-                anchors.horizontalCenter: parent.horizontalCenter
-                horizontalAlignment: Text.AlignHCenter
-                width: parent.width - 2*Theme.horizontalPageMargin
-                wrapMode: Text.WordWrap
-            }
-
-            Label {
                 //% "Source code"
                 text: '<a href="https://github.com/sailfishos-chum/sailfishos-chum-gui">' + qsTrId("chum-about-home") + '</a>'
                 anchors.horizontalCenter: parent.horizontalCenter
@@ -62,6 +53,15 @@ Page {
                 wrapMode: Text.WordWrap
                 linkColor: Theme.highlightColor
                 onLinkActivated: Qt.openUrlExternally(link)
+            }
+
+            Label {
+                //% "License: %1"
+                text: qsTrId("chum-about-license").arg("MIT")
+                anchors.horizontalCenter: parent.horizontalCenter
+                horizontalAlignment: Text.AlignHCenter
+                width: parent.width - 2*Theme.horizontalPageMargin
+                wrapMode: Text.WordWrap
             }
 
             Label {

--- a/qml/pages/AboutPage.qml
+++ b/qml/pages/AboutPage.qml
@@ -26,12 +26,19 @@ Page {
                 anchors.horizontalCenter: parent.horizontalCenter
             }
 
+            // When using the same, theoretically correct, horizontal margin as in
+            // SettingsPage.qml (twice Theme.horizontalPageMargin), centering the text
+            // horizontally makes Qt render a much larger margin (circa twice the size).
+            // Thus halving the margin: width: parent.width - Theme.horizontalPageMargin
+            // The long text of the last label emphasises this issue by using much space
+            // vertically when rendered with such big horizontal margin(s).
+            
             Label {
                 //% "A graphical client application for the SailfishOS:Chum community repository"
                 text: qsTrId("chum-about-store")
                 anchors.horizontalCenter: parent.horizontalCenter
                 horizontalAlignment: Text.AlignHCenter
-                width: parent.width - 2*Theme.horizontalPageMargin
+                width: parent.width - Theme.horizontalPageMargin
                 wrapMode: Text.WordWrap
             }
 
@@ -40,7 +47,7 @@ Page {
                 text: qsTrId("chum-about-version").arg(Qt.application.version)
                 anchors.horizontalCenter: parent.horizontalCenter
                 horizontalAlignment: Text.AlignHCenter
-                width: parent.width - 2*Theme.horizontalPageMargin
+                width: parent.width - Theme.horizontalPageMargin
                 wrapMode: Text.WordWrap
             }
 
@@ -49,7 +56,7 @@ Page {
                 text: '<a href="https://github.com/sailfishos-chum/sailfishos-chum-gui">' + qsTrId("chum-about-home") + '</a>'
                 anchors.horizontalCenter: parent.horizontalCenter
                 horizontalAlignment: Text.AlignHCenter
-                width: parent.width - 2*Theme.horizontalPageMargin
+                width: parent.width - Theme.horizontalPageMargin
                 wrapMode: Text.WordWrap
                 linkColor: Theme.highlightColor
                 onLinkActivated: Qt.openUrlExternally(link)
@@ -60,7 +67,7 @@ Page {
                 text: qsTrId("chum-about-license").arg("MIT")
                 anchors.horizontalCenter: parent.horizontalCenter
                 horizontalAlignment: Text.AlignHCenter
-                width: parent.width - 2*Theme.horizontalPageMargin
+                width: parent.width - Theme.horizontalPageMargin
                 wrapMode: Text.WordWrap
             }
 
@@ -68,7 +75,7 @@ Page {
                 //% "Issue tracker for bug reports, feature suggestions and help requests"
                 text: '<a href="https://github.com/sailfishos-chum/sailfishos-chum-gui/issues">' + qsTrId("chum-about-issues") + '</a>'
                 anchors.horizontalCenter: parent.horizontalCenter
-                width: parent.width - 2*Theme.horizontalPageMargin
+                width: parent.width - Theme.horizontalPageMargin
                 wrapMode: Text.WordWrap
                 horizontalAlignment: Text.AlignHCenter
                 linkColor: Theme.highlightColor
@@ -115,7 +122,7 @@ Page {
                 font.pixelSize: Theme.fontSizeSmall
                 anchors.horizontalCenter: parent.horizontalCenter
                 horizontalAlignment: Text.AlignHCenter
-                width: parent.width - 2*Theme.horizontalPageMargin
+                width: parent.width - Theme.horizontalPageMargin
                 wrapMode: Text.WordWrap
                 linkColor: Theme.highlightColor
                 onLinkActivated: Qt.openUrlExternally(link)

--- a/qml/pages/AboutPage.qml
+++ b/qml/pages/AboutPage.qml
@@ -27,7 +27,7 @@ Page {
             }
 
             Label {
-                //% "A graphical application for the SailfishOS:Chum community repository"
+                //% "A graphical client application for the SailfishOS:Chum community repository"
                 text: qsTrId("chum-about-store")
                 anchors.horizontalCenter: parent.horizontalCenter
                 horizontalAlignment: Text.AlignHCenter
@@ -105,7 +105,7 @@ Page {
                 //% "for keeping the software supply chains of complex packages up-to-date.<br />"
                 //% "<br />"
                 //% "The SailfishOS:Chum repository is located at the Sailfish&nbsp;OS OBS:<br />"
-                //% "<a href='https://build.merproject.org/project/show/sailfishos:chum'>https://build.merproject.org/project/show/sailfishos:chum</a><br />"
+                //% "<a href='https://build.merproject.org/project/show/sailfishos:chum'>build.merproject.org/project/show/sailfishos:chum</a><br />"
                 //% "<br />"
                 //% "For the etymological origin and meanings of the word &quot;chum&quot;, see "
                 //% "<a href='https://en.wikipedia.org/wiki/Chumming'>en.wikipedia.org:Chumming</a> "

--- a/qml/pages/AboutPage.qml
+++ b/qml/pages/AboutPage.qml
@@ -30,8 +30,8 @@ Page {
                 //% "A graphical application for the SailfishOS:Chum community repository"
                 text: qsTrId("chum-about-store")
                 anchors.horizontalCenter: parent.horizontalCenter
-                width: parent.width - 2*Theme.horizontalPageMargin
                 horizontalAlignment: Text.AlignHCenter
+                width: parent.width - 2*Theme.horizontalPageMargin
                 wrapMode: Text.WordWrap
             }
 
@@ -39,20 +39,28 @@ Page {
                 //% "Version: %1"
                 text: qsTrId("chum-about-version").arg(Qt.application.version)
                 anchors.horizontalCenter: parent.horizontalCenter
+                horizontalAlignment: Text.AlignHCenter
+                width: parent.width - 2*Theme.horizontalPageMargin
+                wrapMode: Text.WordWrap
             }
 
             Label {
                 //% "License: %1"
                 text: qsTrId("chum-about-license").arg("MIT")
                 anchors.horizontalCenter: parent.horizontalCenter
+                horizontalAlignment: Text.AlignHCenter
+                width: parent.width - 2*Theme.horizontalPageMargin
+                wrapMode: Text.WordWrap
             }
 
             Label {
                 //% "Source code"
                 text: '<a href="https://github.com/sailfishos-chum/sailfishos-chum-gui">' + qsTrId("chum-about-home") + '</a>'
                 anchors.horizontalCenter: parent.horizontalCenter
-                linkColor: Theme.highlightColor
+                horizontalAlignment: Text.AlignHCenter
+                width: parent.width - 2*Theme.horizontalPageMargin
                 wrapMode: Text.WordWrap
+                linkColor: Theme.highlightColor
                 onLinkActivated: Qt.openUrlExternally(link)
             }
 
@@ -60,8 +68,10 @@ Page {
                 //% "Issue tracker for bug reports, feature suggestions and help requests"
                 text: '<a href="https://github.com/sailfishos-chum/sailfishos-chum-gui/issues">' + qsTrId("chum-about-issues") + '</a>'
                 anchors.horizontalCenter: parent.horizontalCenter
-                linkColor: Theme.highlightColor
+                width: parent.width - 2*Theme.horizontalPageMargin
                 wrapMode: Text.WordWrap
+                horizontalAlignment: Text.AlignHCenter
+                linkColor: Theme.highlightColor
                 onLinkActivated: Qt.openUrlExternally(link)
             }
 
@@ -102,11 +112,11 @@ Page {
                 //% "and <a href='https://en.wiktionary.org/wiki/chum'>en.wiktionary.org:chum</a>."
                 text: qsTrId("chum-about-description")
                 textFormat: Text.StyledText
-                anchors.horizontalCenter: parent.horizontalCenter
-                width: parent.width * 0.8
-                wrapMode: Text.WordWrap
                 font.pixelSize: Theme.fontSizeSmall
+                anchors.horizontalCenter: parent.horizontalCenter
                 horizontalAlignment: Text.AlignHCenter
+                width: parent.width - 2*Theme.horizontalPageMargin
+                wrapMode: Text.WordWrap
                 linkColor: Theme.highlightColor
                 onLinkActivated: Qt.openUrlExternally(link)
             }

--- a/translations/sailfishos-chum-gui.ts
+++ b/translations/sailfishos-chum-gui.ts
@@ -570,36 +570,36 @@ This SailfishOS:Chum GUI application will add any missing SailfishOS:Chum reposi
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-about-store">
-        <location filename="../qml/pages/AboutPage.qml" line="31"/>
-        <source>A graphical application for the SailfishOS:Chum community repository</source>
+        <location filename="../qml/pages/AboutPage.qml" line="38"/>
+        <source>A graphical client application for the SailfishOS:Chum community repository</source>
         <oldsource>A store frontend for the Chum repository</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-about-version">
-        <location filename="../qml/pages/AboutPage.qml" line="40"/>
+        <location filename="../qml/pages/AboutPage.qml" line="47"/>
         <source>Version: %1</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="chum-about-license">
-        <location filename="../qml/pages/AboutPage.qml" line="46"/>
-        <source>License: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message id="chum-about-home">
-        <location filename="../qml/pages/AboutPage.qml" line="52"/>
+        <location filename="../qml/pages/AboutPage.qml" line="56"/>
         <source>Source code</source>
         <oldsource>Home</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="chum-about-license">
+        <location filename="../qml/pages/AboutPage.qml" line="67"/>
+        <source>License: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="chum-about-issues">
-        <location filename="../qml/pages/AboutPage.qml" line="61"/>
+        <location filename="../qml/pages/AboutPage.qml" line="76"/>
         <source>Issue tracker for bug reports, feature suggestions and help requests</source>
         <oldsource>Issue tracker</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-about-description">
-        <location filename="../qml/pages/AboutPage.qml" line="103"/>
-        <source>The SailfishOS:Chum community repository provides a collection of applications, tools and libraries compiled for various hardware architectures and Sailfish&amp;nbsp;OS release versions.&lt;br /&gt;&lt;br /&gt;In contrast to the software distribution model of the Jolla Store or OpenRepos, to which binary packages are uploaded by developers, at SailfishOS:Chum software is compiled and packaged into RPMs in a reproducible manner directly from its source code. The source code used for compiling and packaging is submitted by developers to OBS (Open Build Service), which generates multiple RPM files for different combinations of hardware architectures and Sailfish&amp;nbsp;OS release versions.&lt;br /&gt;&lt;br /&gt;This scheme ensures that the complete source code of all packages at SailfishOS:Chum is available and inspectable there, and that all packages are generated solely from this source code. Hence all software packages at SailfishOS:Chum are created in a transparent and fully traceable manner.&lt;br /&gt;&lt;br /&gt;By collecting software for Sailfish&amp;nbsp;OS in a single automated build system, collaboration between developers through common packaging of shared libraries etc. is fostered, duplication of work for keeping these common packages up-to-date is eliminated, and it becomes much easier to determine which pieces of software exist and which are missing at the Sailfish&amp;nbsp;OS OBS. Additionally this eases tracing multiple and potentially layered dependencies (&amp;quot;dependency chains&amp;quot;) which is crucial for keeping the software supply chains of complex packages up-to-date.&lt;br /&gt;&lt;br /&gt;The SailfishOS:Chum repository is located at the Sailfish&amp;nbsp;OS OBS:&lt;br /&gt;&lt;a href=&apos;https://build.merproject.org/project/show/sailfishos:chum&apos;&gt;https://build.merproject.org/project/show/sailfishos:chum&lt;/a&gt;&lt;br /&gt;&lt;br /&gt;For the etymological origin and meanings of the word &amp;quot;chum&amp;quot;, see &lt;a href=&apos;https://en.wikipedia.org/wiki/Chumming&apos;&gt;en.wikipedia.org:Chumming&lt;/a&gt; and &lt;a href=&apos;https://en.wiktionary.org/wiki/chum&apos;&gt;en.wiktionary.org:chum&lt;/a&gt;.</source>
+        <location filename="../qml/pages/AboutPage.qml" line="120"/>
+        <source>The SailfishOS:Chum community repository provides a collection of applications, tools and libraries compiled for various hardware architectures and Sailfish&amp;nbsp;OS release versions.&lt;br /&gt;&lt;br /&gt;In contrast to the software distribution model of the Jolla Store or OpenRepos, to which binary packages are uploaded by developers, at SailfishOS:Chum software is compiled and packaged into RPMs in a reproducible manner directly from its source code. The source code used for compiling and packaging is submitted by developers to OBS (Open Build Service), which generates multiple RPM files for different combinations of hardware architectures and Sailfish&amp;nbsp;OS release versions.&lt;br /&gt;&lt;br /&gt;This scheme ensures that the complete source code of all packages at SailfishOS:Chum is available and inspectable there, and that all packages are generated solely from this source code. Hence all software packages at SailfishOS:Chum are created in a transparent and fully traceable manner.&lt;br /&gt;&lt;br /&gt;By collecting software for Sailfish&amp;nbsp;OS in a single automated build system, collaboration between developers through common packaging of shared libraries etc. is fostered, duplication of work for keeping these common packages up-to-date is eliminated, and it becomes much easier to determine which pieces of software exist and which are missing at the Sailfish&amp;nbsp;OS OBS. Additionally this eases tracing multiple and potentially layered dependencies (&amp;quot;dependency chains&amp;quot;) which is crucial for keeping the software supply chains of complex packages up-to-date.&lt;br /&gt;&lt;br /&gt;The SailfishOS:Chum repository is located at the Sailfish&amp;nbsp;OS OBS:&lt;br /&gt;&lt;a href=&apos;https://build.merproject.org/project/show/sailfishos:chum&apos;&gt;build.merproject.org/project/show/sailfishos:chum&lt;/a&gt;&lt;br /&gt;&lt;br /&gt;For the etymological origin and meanings of the word &amp;quot;chum&amp;quot;, see &lt;a href=&apos;https://en.wikipedia.org/wiki/Chumming&apos;&gt;en.wikipedia.org:Chumming&lt;/a&gt; and &lt;a href=&apos;https://en.wiktionary.org/wiki/chum&apos;&gt;en.wiktionary.org:chum&lt;/a&gt;.</source>
         <oldsource>Sailfish OS Community repositories provide a collection of applications, tools, and libraries compiled for different combinations of architectures and Sailfish versions.&lt;br&gt;&lt;br&gt;The ambition is to become the main repository for software distribution on Sailfish OS. When compared to software distribution via Jolla Store or OpenRepos, the software is compiled into RPMs in a reproducible way directly from the source. The source used for the compilation is available at OBS together with the compiled packages. This is in contrast with the Jolla Store and OpenRepos where all packages are uploaded in binary form without any control over how the binary was compiled.&lt;br&gt;&lt;br&gt;By collecting the software in a single automated build system, we can benefit from collaboration between developers through shared packaging of required libraries, reduce duplication of work by keeping the packages up to date, and get a clear overview of missing software.</oldsource>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
Because else [any `wrapMode` except for `NoWrap` is not applied](https://github.com/sailfishos-chum/sailfishos-chum-gui/pull/154#issuecomment-1477181758)
Also order the properties and set the `width` of all labels alike.

*Edit:* After reviewing and viewing thoroughly, additionally performed the following changes.
- [Adding "client" & shorten a link in strings](https://github.com/sailfishos-chum/sailfishos-chum-gui/pull/176/commits/d8d92200a41becbcdb7f7fe5f58cb26d2eddb768)
- [Move "Source code" one up to separate links better](https://github.com/sailfishos-chum/sailfishos-chum-gui/pull/176/commits/bfa5b781796f18e6d83a08556d344ffe5cb76e90)
- [Halving horizontal margin(s)](https://github.com/sailfishos-chum/sailfishos-chum-gui/pull/176/commits/d915990fcd3655bce2f445e506d12f05a0149cf4)
  See comment in lines 29 to 33 for details and this [screenshot of the original appearance](https://user-images.githubusercontent.com/23747593/226488109-32c78f22-963f-4061-b30a-06c78d6c99d6.png).
- [Align with strings in source file AboutPage.qml](https://github.com/sailfishos-chum/sailfishos-chum-gui/pull/176/commits/d345031a5ba8e3417cbf15dcb2dd9b8290717195)