### PR TITLE
Add help message for applying version override

### DIFF
--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -110,7 +110,7 @@ Page {
 
             TextFieldDesc {
                 id: txtRelease
-                //% "Usually a specific SailfishOS:Chum repository is automatically selected according to the "
+                //% "Press Enter to apply. Usually a specific SailfishOS:Chum repository is automatically selected according to the "
                 //% "installed Sailfish OS release version. To manually select a SailfishOS:Chum repository for "
                 //% "a specific Sailfish OS release, specify this Sailfish OS release here (for example, 4.3.0.12). "
                 //% "This is useful when the SailfishOS:Chum repository is not available for the installed "

--- a/translations/sailfishos-chum-gui.ts
+++ b/translations/sailfishos-chum-gui.ts
@@ -477,8 +477,8 @@ This SailfishOS:Chum GUI application will add any missing SailfishOS:Chum reposi
     </message>
     <message id="chum-setings-override-release-description">
         <location filename="../qml/pages/SettingsPage.qml" line="118"/>
-        <source>Usually a specific SailfishOS:Chum repository is automatically selected according to the installed Sailfish OS release version. To manually select a SailfishOS:Chum repository for a specific Sailfish OS release, specify this Sailfish OS release here (for example, 4.3.0.12). This is useful when the SailfishOS:Chum repository is not available for the installed Sailfish OS version, as for Cbeta users.</source>
-        <oldsource>Usually a specific SailfishOS:Chum repository is automatically selected according to the installed Sailfish OS release version. To subscribe to a SailfishOS:Chum repository for a specific Sailfish OS release, specify this Sailfish OS release here (for example, 4.3.0.12). This is useful when the SailfishOS:Chum repository is not available for the installed Sailfish OS version, as for Cbeta users.</oldsource>
+        <source>Press Enter to apply. Usually a specific SailfishOS:Chum repository is automatically selected according to the installed Sailfish OS release version. To manually select a SailfishOS:Chum repository for a specific Sailfish OS release, specify this Sailfish OS release here (for example, 4.3.0.12). This is useful when the SailfishOS:Chum repository is not available for the installed Sailfish OS version, as for Cbeta users.</source>
+        <oldsource>Press Enter to apply.&lt;br&gt;Usually a specific SailfishOS:Chum repository is automatically selected according to the installed Sailfish OS release version. To manually select a SailfishOS:Chum repository for a specific Sailfish OS release, specify this Sailfish OS release here (for example, 4.3.0.12). This is useful when the SailfishOS:Chum repository is not available for the installed Sailfish OS version, as for Cbeta users.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-setings-override-release-placeholder">


### PR DESCRIPTION
Turns out that functionality was there. We just have to press Enter to apply config change. Added corresponding help message.

Please review.

Fixes: #184 