### PR TITLE
Delete stale or incoherent `<oldsource>` strings

### DIFF
--- a/translations/sailfishos-chum-gui.ts
+++ b/translations/sailfishos-chum-gui.ts
@@ -21,7 +21,6 @@
     <message id="chum-packages-list-apply-all-updates">
         <location filename="../qml/pages/PackagesListPage.qml" line="111"/>
         <source>Update all</source>
-        <oldsource>Apply all updates</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-updates-available" numerus="yes">
@@ -46,7 +45,6 @@
     <message id="chum-package-uninstalled">
         <location filename="../qml/sailfishos-chum-gui.qml" line="22"/>
         <source>%1 %2 removed</source>
-        <oldsource>%1 %2 uninstalled</oldsource>
         <extracomment>%1 - package name, %2 - package version</extracomment>
         <translation type="unfinished"></translation>
     </message>
@@ -70,13 +68,11 @@
     <message id="chum-refresh-cache">
         <location filename="../qml/pages/MainPage.qml" line="53"/>
         <source>Refresh repository</source>
-        <oldsource>Refresh cache</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-no-updates">
         <location filename="../qml/pages/MainPage.qml" line="71"/>
         <source>No updates available</source>
-        <oldsource>No update available</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-updates">
@@ -114,25 +110,21 @@
     <message id="chum-package-project-repo">
         <location filename="../qml/pages/PackagePage.qml" line="29"/>
         <source>Source code</source>
-        <oldsource>Project Repository</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-package-file-issue">
         <location filename="../qml/pages/PackagePage.qml" line="35"/>
         <source>Issue tracker</source>
-        <oldsource>File Issue</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-package-discussion-forum">
         <location filename="../qml/pages/PackagePage.qml" line="41"/>
         <source>Discussion forum</source>
-        <oldsource>Discussion Forum</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-uninstalling">
         <location filename="../qml/pages/PackagePage.qml" line="24"/>
         <source>Removing</source>
-        <oldsource>Uninstalling</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-update">
@@ -151,13 +143,11 @@
         <location filename="../qml/pages/PackagePage.qml" line="21"/>
         <location filename="../qml/pages/PackagesListPage.qml" line="72"/>
         <source>Remove</source>
-        <oldsource>Uninstall</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-package-donation">
         <location filename="../qml/pages/PackagePage.qml" line="126"/>
         <source>Donate</source>
-        <oldsource>Make Dontation</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-pkg-update-available">
@@ -183,7 +173,6 @@
     <message id="chum-pkg-categories">
         <location filename="../qml/components/AppSummary.qml" line="66"/>
         <source>Categories:</source>
-        <oldsource>Categories</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-releases-number">
@@ -204,49 +193,41 @@
     <message id="chum-load-repositories">
         <location filename="../src/chum.cpp" line="42"/>
         <source>Loading SailfishOS:Chum repository</source>
-        <oldsource>Load repositories</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-get-list-packages">
         <location filename="../src/chum.cpp" line="104"/>
         <source>Retrieving list of available packages</source>
-        <oldsource>Get list of packages</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-get-package-details">
         <location filename="../src/chum.cpp" line="181"/>
         <source>Retrieving the current detail information for installed packages</source>
-        <oldsource>Get package details</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-get-package-version">
         <location filename="../src/chum.cpp" line="211"/>
         <source>Retrieving the currently available versions of installed packages</source>
-        <oldsource>Get versions of installed packages</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-check-updates">
         <location filename="../src/chum.cpp" line="258"/>
         <source>Checking for which installed packages an update is available</source>
-        <oldsource>Check for updates</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-refresh-repository-impossible">
         <location filename="../src/chum.cpp" line="293"/>
         <source>Failed to refresh SailfishOS:Chum repository, because it is not available!</source>
-        <oldsource>Cannot refresh repository as it is not available</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-refresh-repository">
         <location filename="../src/chum.cpp" line="303"/>
         <source>Refreshing SailfishOS:Chum repository</source>
-        <oldsource>Refreshing Chum repository</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-refresh-repository-failed">
         <location filename="../src/chum.cpp" line="320"/>
         <source>Failed to refresh SailfishOS:Chum repository!</source>
-        <oldsource>Failed to refresh Chum repository</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-repo-management-disabled-title">
@@ -254,7 +235,6 @@
         <location filename="../src/chum.cpp" line="329"/>
         <location filename="../src/chum.cpp" line="351"/>
         <source>Repositories misconfigured.</source>
-        <oldsource>Repositories misconfigured</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-repo-management-disabled-txt">
@@ -264,54 +244,42 @@
 Please remove all SailfishOS:Chum repositories by executing this command line as root user:
 for i in $(ssu lr | fgrep chum | cut -f 3 -d &apos; &apos;); do ssu rr $i; done
 This SailfishOS:Chum GUI application will add any missing SailfishOS:Chum repository when started again.</source>
-        <oldsource>The SailfishOS:Chum GUI application failed to manage the SailfishOS:Chum repository. You probably have multiple SailfishOS:Chum repositories defined for SSU or disabled a SailfishOS:Chum repository.
-
-Please remove all SailfishOS:Chum repositories by executing this command line as root user:
-for i in $(ssu lr | fgrep chum | cut -f 3 -d &apos; &apos;); do ssu rr $i; done
-This SailfishOS:Chum GUI application will add any missing SailfishOS:Chum repository when started again.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-add-repo">
         <location filename="../src/chum.cpp" line="342"/>
         <source>Adding SailfishOS:Chum repository</source>
-        <oldsource>Adding Chum repository</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-add-testing-repo">
         <location filename="../src/chum.cpp" line="80"/>
         <location filename="../src/chum.cpp" line="359"/>
         <source>Adding SailfishOS:Chum:Testing repository</source>
-        <oldsource>Setting up Chum repository</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-install-package">
         <location filename="../src/chum.cpp" line="372"/>
         <source>Installing package</source>
-        <oldsource>Install package</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-uninstall-package">
         <location filename="../src/chum.cpp" line="384"/>
         <source>Removing package</source>
-        <oldsource>Uninstall package</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-update-package">
         <location filename="../src/chum.cpp" line="396"/>
         <source>Updating package</source>
-        <oldsource>Update package</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-update-all-packages">
         <location filename="../src/chum.cpp" line="412"/>
         <source>Updating all packages</source>
-        <oldsource>Update all packages</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-release">
         <location filename="../qml/pages/ReleasePage.qml" line="36"/>
         <source>Release</source>
-        <oldsource>Release %1</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-issues">
@@ -348,55 +316,46 @@ This SailfishOS:Chum GUI application will add any missing SailfishOS:Chum reposi
     <message id="chum-pkg-developer">
         <location filename="../qml/components/AppInformation.qml" line="65"/>
         <source>Developer:</source>
-        <oldsource>Developer</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-pkg-installed-version">
         <location filename="../qml/components/AppInformation.qml" line="72"/>
         <source>Installed version:</source>
-        <oldsource>Installed version</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-pkg-available-version">
         <location filename="../qml/components/AppInformation.qml" line="78"/>
         <source>Available version:</source>
-        <oldsource>Available version</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-pkg-package-name">
         <location filename="../qml/components/AppInformation.qml" line="85"/>
         <source>Package name:</source>
-        <oldsource>Package name</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-pkg-download-size">
         <location filename="../qml/components/AppInformation.qml" line="92"/>
         <source>Download size:</source>
-        <oldsource>Download size</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-pkg-license">
         <location filename="../qml/components/AppInformation.qml" line="99"/>
         <source>License:</source>
-        <oldsource>License</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-pkg-link">
         <location filename="../qml/components/AppInformation.qml" line="110"/>
         <source>Homepage:</source>
-        <oldsource>Link</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-pkg-packaging-link">
         <location filename="../qml/components/AppInformation.qml" line="122"/>
         <source>Packaging repository:</source>
-        <oldsource>Packaging repository</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-settings-status-repo-management-failed">
         <location filename="../qml/pages/SettingsPage.qml" line="40"/>
         <source>SailfishOS:Chum repository management failed</source>
-        <oldsource>Chum repository management failed</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-settings-status">
@@ -407,55 +366,46 @@ This SailfishOS:Chum GUI application will add any missing SailfishOS:Chum reposi
     <message id="chum-settings-status-repo-not-available">
         <location filename="../qml/pages/SettingsPage.qml" line="47"/>
         <source>SailfishOS:Chum repository is not available</source>
-        <oldsource>Chum repository is not available</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-settings-status-repo-testing-manual">
         <location filename="../qml/pages/SettingsPage.qml" line="52"/>
         <source>Subscribed to the SailfishOS:Chum:Testing repository with a manually set Sailfish OS version (%1).</source>
-        <oldsource>Subscribed to the SailfishOS:Chum testing repository with a manually set Sailfish&amp;nbsp;OS version (%1).</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-settings-status-repo-regular-manual">
         <location filename="../qml/pages/SettingsPage.qml" line="54"/>
         <source>Subscribed to the regular SailfishOS:Chum repository with a manually set Sailfish OS version (%1).</source>
-        <oldsource>Subscribed to the regular SailfishOS:Chum repository with a manually set Sailfish&amp;nbsp;OS version (%1).</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-settings-status-repo-testing-auto">
         <location filename="../qml/pages/SettingsPage.qml" line="57"/>
         <source>Subscribed to the SailfishOS:Chum:Testing repository with an automatically determined Sailfish OS version.</source>
-        <oldsource>Subscribed to the SailfishOS:Chum testing repository with an automatically determined Sailfish&amp;nbsp;OS version.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-settings-status-repo-regular-auto">
         <location filename="../qml/pages/SettingsPage.qml" line="59"/>
         <source>Subscribed to the regular SailfishOS:Chum repository with an automatically determined Sailfish OS version.</source>
-        <oldsource>Subscribed to the regular SailfishOS:Chum repository with an automatically determined Sailfish&amp;nbsp;OS version.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-settings-general">
         <location filename="../qml/pages/SettingsPage.qml" line="67"/>
         <source>General settings</source>
-        <oldsource>General</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-settings-show-apps-description">
         <location filename="../qml/pages/SettingsPage.qml" line="75"/>
         <source>When listing available software packages, by default only applications are shown. But every listing can be toggled between showing solely applications or all packages by using the corresponding switch in the pulley menu.</source>
-        <oldsource>When listing available software packages, by default only applications are shown. But for each listing you can switch between showing only applications or all packages by using the corresponding switch in the pulley menu.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-settings-show-apps">
         <location filename="../qml/pages/SettingsPage.qml" line="77"/>
         <source>Show applications only</source>
-        <oldsource>Show applications only by default</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-settings-testing-description">
         <location filename="../qml/pages/SettingsPage.qml" line="92"/>
         <source>Use the SailfishOS:Chum:Testing repository. This is mainly useful for developers to test their packages before publishing.</source>
-        <oldsource>Use testing version of Chum repository. This is mainly useful for developers for testing their packages before publishing.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-settings-testing">
@@ -466,25 +416,21 @@ This SailfishOS:Chum GUI application will add any missing SailfishOS:Chum reposi
     <message id="chum-settings-advanced">
         <location filename="../qml/pages/SettingsPage.qml" line="83"/>
         <source>Advanced settings</source>
-        <oldsource>Advanced</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-settings-override-selection">
         <location filename="../qml/pages/SettingsPage.qml" line="107"/>
         <source>Override the automatic SailfishOS:Chum repository selection</source>
-        <oldsource>Override SailfishOS:Chum repository selection</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-setings-override-release-description">
         <location filename="../qml/pages/SettingsPage.qml" line="118"/>
         <source>Press Enter to apply. Usually a specific SailfishOS:Chum repository is automatically selected according to the installed Sailfish OS release version. To manually select a SailfishOS:Chum repository for a specific Sailfish OS release, specify this Sailfish OS release here (for example, 4.3.0.12). This is useful when the SailfishOS:Chum repository is not available for the installed Sailfish OS version, as for Cbeta users.</source>
-        <oldsource>Press Enter to apply.&lt;br&gt;Usually a specific SailfishOS:Chum repository is automatically selected according to the installed Sailfish OS release version. To manually select a SailfishOS:Chum repository for a specific Sailfish OS release, specify this Sailfish OS release here (for example, 4.3.0.12). This is useful when the SailfishOS:Chum repository is not available for the installed Sailfish OS version, as for Cbeta users.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-setings-override-release-placeholder">
         <location filename="../qml/pages/SettingsPage.qml" line="120"/>
         <source>Specify a Sailfish OS version</source>
-        <oldsource>Specify a Sailfish&amp;nbsp;OS version</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-categories">
@@ -566,13 +512,11 @@ This SailfishOS:Chum GUI application will add any missing SailfishOS:Chum reposi
     <message id="chum-about-gui">
         <location filename="../qml/pages/AboutPage.qml" line="19"/>
         <source>About SailfishOS:Chum GUI</source>
-        <oldsource>About the SailfishOS:Chum GUI</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-about-store">
         <location filename="../qml/pages/AboutPage.qml" line="38"/>
         <source>A graphical client application for the SailfishOS:Chum community repository</source>
-        <oldsource>A store frontend for the Chum repository</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-about-version">
@@ -583,7 +527,6 @@ This SailfishOS:Chum GUI application will add any missing SailfishOS:Chum reposi
     <message id="chum-about-home">
         <location filename="../qml/pages/AboutPage.qml" line="56"/>
         <source>Source code</source>
-        <oldsource>Home</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-about-license">
@@ -594,13 +537,11 @@ This SailfishOS:Chum GUI application will add any missing SailfishOS:Chum reposi
     <message id="chum-about-issues">
         <location filename="../qml/pages/AboutPage.qml" line="76"/>
         <source>Issue tracker for bug reports, feature suggestions and help requests</source>
-        <oldsource>Issue tracker</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-about-description">
         <location filename="../qml/pages/AboutPage.qml" line="120"/>
         <source>The SailfishOS:Chum community repository provides a collection of applications, tools and libraries compiled for various hardware architectures and Sailfish&amp;nbsp;OS release versions.&lt;br /&gt;&lt;br /&gt;In contrast to the software distribution model of the Jolla Store or OpenRepos, to which binary packages are uploaded by developers, at SailfishOS:Chum software is compiled and packaged into RPMs in a reproducible manner directly from its source code. The source code used for compiling and packaging is submitted by developers to OBS (Open Build Service), which generates multiple RPM files for different combinations of hardware architectures and Sailfish&amp;nbsp;OS release versions.&lt;br /&gt;&lt;br /&gt;This scheme ensures that the complete source code of all packages at SailfishOS:Chum is available and inspectable there, and that all packages are generated solely from this source code. Hence all software packages at SailfishOS:Chum are created in a transparent and fully traceable manner.&lt;br /&gt;&lt;br /&gt;By collecting software for Sailfish&amp;nbsp;OS in a single automated build system, collaboration between developers through common packaging of shared libraries etc. is fostered, duplication of work for keeping these common packages up-to-date is eliminated, and it becomes much easier to determine which pieces of software exist and which are missing at the Sailfish&amp;nbsp;OS OBS. Additionally this eases tracing multiple and potentially layered dependencies (&amp;quot;dependency chains&amp;quot;) which is crucial for keeping the software supply chains of complex packages up-to-date.&lt;br /&gt;&lt;br /&gt;The SailfishOS:Chum repository is located at the Sailfish&amp;nbsp;OS OBS:&lt;br /&gt;&lt;a href=&apos;https://build.merproject.org/project/show/sailfishos:chum&apos;&gt;build.merproject.org/project/show/sailfishos:chum&lt;/a&gt;&lt;br /&gt;&lt;br /&gt;For the etymological origin and meanings of the word &amp;quot;chum&amp;quot;, see &lt;a href=&apos;https://en.wikipedia.org/wiki/Chumming&apos;&gt;en.wikipedia.org:Chumming&lt;/a&gt; and &lt;a href=&apos;https://en.wiktionary.org/wiki/chum&apos;&gt;en.wiktionary.org:chum&lt;/a&gt;.</source>
-        <oldsource>Sailfish OS Community repositories provide a collection of applications, tools, and libraries compiled for different combinations of architectures and Sailfish versions.&lt;br&gt;&lt;br&gt;The ambition is to become the main repository for software distribution on Sailfish OS. When compared to software distribution via Jolla Store or OpenRepos, the software is compiled into RPMs in a reproducible way directly from the source. The source used for the compilation is available at OBS together with the compiled packages. This is in contrast with the Jolla Store and OpenRepos where all packages are uploaded in binary form without any control over how the binary was compiled.&lt;br&gt;&lt;br&gt;By collecting the software in a single automated build system, we can benefit from collaboration between developers through shared packaging of required libraries, reduce duplication of work by keeping the packages up to date, and get a clear overview of missing software.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="chum-desc-library">


### PR DESCRIPTION
I am unsure if the `<oldsource>` strings are still useful, now that the localisation principally happens at Transifex, which does not use or display them.  It tend to "No".

As I am undecided, I let somebody else meet this decision and either merge this PR or close it unmerged.