### PR TITLE
Add support for Forgejo/Gitea remote repos

### DIFF
--- a/.github/workflows/ci-on-pull_req.yml
+++ b/.github/workflows/ci-on-pull_req.yml
@@ -54,8 +54,10 @@ jobs:
            mkdir -p rpmbuild/SOURCES
            printf %s "${{ secrets.TOKEN_GITHUB }}" > rpmbuild/SOURCES/token-github.txt
            printf %s "${{ secrets.TOKEN_GITLAB }}" > rpmbuild/SOURCES/token-gitlab.txt
+           printf %s "${{ secrets.TOKEN_FORGEJO }}" > rpmbuild/SOURCES/token-forgejo.txt
            mkdir -p build/rpm
            cp rpmbuild/SOURCES/token-git??b.txt build/rpm/
+           cp rpmbuild/SOURCES/token-forgejo.txt build/rpm/
            cd build
            cp -r /share/. .
            mb2 -t SailfishOS-$1-$2 build -d

--- a/.github/workflows/ci-on-tags.yml
+++ b/.github/workflows/ci-on-tags.yml
@@ -67,8 +67,10 @@ jobs:
            mkdir -p rpmbuild/SOURCES
            printf %s "${{ secrets.TOKEN_GITHUB }}" > rpmbuild/SOURCES/token-github.txt
            printf %s "${{ secrets.TOKEN_GITLAB }}" > rpmbuild/SOURCES/token-gitlab.txt
+           printf %s "${{ secrets.TOKEN_FORGEJO }}" > rpmbuild/SOURCES/token-forgejo.txt
            mkdir -p build/rpm
            cp rpmbuild/SOURCES/token-git??b.txt build/rpm/
+           cp rpmbuild/SOURCES/token-forgejo.txt build/rpm/
            cd build
            cp -r /share/. .
            mb2 -t SailfishOS-$1-$2 build -d
@@ -84,8 +86,10 @@ jobs:
            mkdir -p rpmbuild/SOURCES
            printf %s "${{ secrets.TOKEN_GITHUB }}" > rpmbuild/SOURCES/token-github.txt
            printf %s "${{ secrets.TOKEN_GITLAB }}" > rpmbuild/SOURCES/token-gitlab.txt
+           printf %s "${{ secrets.TOKEN_FORGEJO }}" > rpmbuild/SOURCES/token-forgejo.txt
            mkdir -p build/rpm
            cp rpmbuild/SOURCES/token-git??b.txt build/rpm/
+           cp rpmbuild/SOURCES/token-forgejo.txt build/rpm/
            cd build
            cp -r /share/. .
            mb2 -t SailfishOS-$1-$2 build -d
@@ -101,8 +105,10 @@ jobs:
            mkdir -p rpmbuild/SOURCES
            printf %s "${{ secrets.TOKEN_GITHUB }}" > rpmbuild/SOURCES/token-github.txt
            printf %s "${{ secrets.TOKEN_GITLAB }}" > rpmbuild/SOURCES/token-gitlab.txt
+           printf %s "${{ secrets.TOKEN_FORGEJO }}" > rpmbuild/SOURCES/token-forgejo.txt
            mkdir -p build/rpm
            cp rpmbuild/SOURCES/token-git??b.txt build/rpm/
+           cp rpmbuild/SOURCES/token-forgejo.txt build/rpm/
            cd build
            cp -r /share/. .
            mb2 -t SailfishOS-$1-$2 build -d

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ project(sailfishos-chum-gui
 
 set(GITHUB_TOKEN "unset" CACHE STRING "GitHub access token for GraphQL queries")
 set(GITLAB_TOKEN "unset" CACHE STRING "GitLab.com access token for GraphQL queries")
+set(FORGEJO_TOKEN "unset" CACHE STRING "Forgejo (and Gitea) access token for API queries")
 
 include(FindPkgConfig)
 

--- a/rpm/sailfishos-chum-gui.spec
+++ b/rpm/sailfishos-chum-gui.spec
@@ -14,6 +14,7 @@ Vendor:         chum
 Source0:        %{url}/archive/%{release}/%{version}/%{name}-%{version}.tar.gz
 Source1:        token-github.txt
 Source2:        token-gitlab.txt
+Source3:        token-forgejo.txt
 Source99:       %{name}.rpmlintrc
 Requires:       sailfishsilica-qt5 >= 0.10.9
 Requires:       ssu
@@ -96,6 +97,7 @@ Links:
        -DCMAKE_INSTALL_RPATH=%{_datadir}/%{name}/lib:  \
        -DGITHUB_TOKEN=%(cat %{SOURCE1})  \
        -DGITLAB_TOKEN=%(cat %{SOURCE2})  \
+       -DFORGEJO_TOKEN=%(cat %{SOURCE3})  \
        .
 cmake --build .
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,6 +42,10 @@ set_source_files_properties(projectgitlab.cpp PROPERTIES
   COMPILE_DEFINITIONS GITLAB_TOKEN=\"${GITLAB_TOKEN}\"
 )
 
+set_source_files_properties(projectforgejo.cpp PROPERTIES
+  COMPILE_DEFINITIONS FORGEJO_TOKEN=\"${FORGEJO_TOKEN}\"
+)
+
 target_link_libraries(${PROJECT_NAME}
   Qt5::Quick
   Qt5::DBus

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,8 @@ add_executable(${PROJECT_NAME}
   loadableobject.h
   projectabstract.cpp
   projectabstract.h
+  projectforgejo.h
+  projectforgejo.cpp
   projectgithub.cpp
   projectgithub.h
   projectgitlab.cpp

--- a/src/chumpackage.cpp
+++ b/src/chumpackage.cpp
@@ -2,6 +2,7 @@
 
 #include "projectgithub.h"
 #include "projectgitlab.h"
+#include "projectforgejo.h"
 
 #include <PackageKit/Daemon>
 #include <PackageKit/Details>
@@ -234,6 +235,8 @@ void ChumPackage::setDetails(const PackageKit::Details &v) {
             m_project = new ProjectGitHub(u, this);
         else if (ProjectGitLab::isProject(u))
             m_project = new ProjectGitLab(u, this);
+        else if (ProjectForgejo::isProject(u))
+            m_project = new ProjectForgejo(u, this);
         if (m_project) break;
     }
 

--- a/src/projectforgejo.cpp
+++ b/src/projectforgejo.cpp
@@ -1,0 +1,298 @@
+#include "projectforgejo.h"
+#include "chumpackage.h"
+#include "main.h"
+
+#include <QDebug>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+#include <QLocale>
+#include <QNetworkRequest>
+#include <QNetworkReply>
+#include <QSharedPointer>
+#include <QUrl>
+#include <QVariantList>
+#include <QVariantMap>
+
+QMap<QString, QString> ProjectForgejo::s_sites;
+
+//////////////////////////////////////////////////////
+/// helper functions
+
+static QString getName(const QVariant &v) {
+  QVariantMap m = v.toMap();
+  QString login = m[QLatin1String("username")].toString();
+  QString name = m[QLatin1String("full_name")].toString();
+  if (login.isEmpty() || name==login) return name;
+  if (name.isEmpty()) return login;
+  return QStringLiteral("%1 (%2)").arg(name, login);
+}
+
+static void parseUrl(const QString &u, QString &h, QString &path) {
+  QUrl url(u);
+  h = url.host();
+  QString p = url.path();
+  if (p.startsWith('/')) p = p.mid(1);
+  if (p.endsWith('/')) p.chop(1);
+  path = p;
+}
+
+//////////////////////////////////////////////////////
+/// ProjectForgejo
+
+ProjectForgejo::ProjectForgejo(const QString &url, ChumPackage *package) : ProjectAbstract(package) {
+  initSites();
+  parseUrl(url, m_host, m_path);
+  if (!s_sites.contains(m_host)) {
+    qWarning() << "Shouldn't happen: ProjectForgejo initialized with incorrect service" << url;
+    return;
+  }
+
+  m_token = s_sites.value(m_host, QString{});
+
+  // url is not set as it can be different homepage that is retrieved from query
+  m_package->setUrlIssues(QStringLiteral("https://%1/%2/issues").arg(m_host, m_path));
+
+  // fetch information from Forgejo
+  fetchRepoInfo();
+}
+
+// static
+void ProjectForgejo::initSites() {
+  if (!s_sites.isEmpty()) return;
+  for (const QString &sitetoken: QStringLiteral(FORGEJO_TOKEN).split(QChar('|'))) {
+      QStringList st = sitetoken.split(QChar(':'));
+      if (st.size() != 2) {
+          qWarning() << "Error parsing provided Forgejo site-token pairs";
+          return;
+      }
+      s_sites[st[0]] = st[1];
+      qDebug() << "Forgejo support added for" << st[0];
+  }
+}
+
+// static
+bool ProjectForgejo::isProject(const QString &url) {
+  initSites();
+  QString h, p;
+  parseUrl(url, h, p);
+  return s_sites.contains(h);
+}
+
+QNetworkReply* ProjectForgejo::sendQuery(const QString &query) {
+  QString reqAuth = QStringLiteral("token %1").arg(m_token);
+  QString reqUrl = QStringLiteral("https://%1/api/v1%2").arg(m_host).arg(query);
+  QNetworkRequest request;
+  request.setUrl(reqUrl);
+  request.setRawHeader("Content-Type", "application/json");
+  request.setRawHeader("Authorization", reqAuth.toLocal8Bit());
+  return nMng->get(request);
+}
+
+void ProjectForgejo::fetchRepoInfo() {
+  QNetworkReply *reply = sendQuery(QStringLiteral("/repos/%1").arg(m_path));
+  connect(reply, &QNetworkReply::finished, this, [this, reply](){
+    if (reply->error() != QNetworkReply::NoError) {
+      qWarning() << "Forgejo: Failed to fetch repository data for Forgejo" << this->m_path;
+      qWarning() << "Forgejo: Error: " << reply->errorString();
+    }
+
+    QByteArray data = reply->readAll();
+    QJsonObject r = QJsonDocument::fromJson(data).object();
+
+    QString v;
+    int vi;
+
+    v = r.value("owner").toObject().value("login").toString();
+    if (!v.isEmpty()) m_package->setDeveloperLogin(v);
+
+    v = r.value("owner").toObject().value("full_name").toString();
+    if (!v.isEmpty()) m_package->setDeveloperName(v);
+
+    v = r.value("website").toString();
+    if (!v.isEmpty()) m_package->setUrl(v);
+
+    vi = r.value("stars_count").toInt(-1);
+    if (vi>=0) m_package->setStarsCount(vi);
+
+    vi = r.value("forks_count").toInt(-1);
+    if (vi>=0) m_package->setForksCount(vi);
+
+    vi = r.value("open_issues_count").toInt(-1);
+    if (vi>=0) m_package->setIssuesCount(vi);
+
+    vi = r.value("release_counter").toInt(-1);
+    if (vi>=0) m_package->setReleasesCount(vi);
+
+    reply->deleteLater();
+  });
+}
+
+void ProjectForgejo::comments(const QString &issue_id, const QVariantMap &comment, LoadableObject *value) {
+  QNetworkReply *reply = sendQuery( QStringLiteral("/repos/%1/issues/%2/comments").arg(m_path).arg(issue_id));
+  connect(reply, &QNetworkReply::finished, this, [this, issue_id, comment, reply, value](){
+    if (reply->error() != QNetworkReply::NoError) {
+      qWarning() << "Forgejo: Failed to fetch issue for" << this->m_path;
+      qWarning() << "Forgejo: Error: " << reply->errorString();
+    }
+
+    QByteArray data = reply->readAll();
+    QVariantList r = QJsonDocument::fromJson(data).array().toVariantList();
+
+    QVariantList rlist;
+    rlist.append(comment); // add issue comment as first comment
+    for (const auto &e: r) {
+      QVariantMap element = e.toMap();
+      QVariantMap m;
+      m["author"] = getName(element.value("user"));
+      m["created"] = parseDate(element.value("created_at").toString(), true);
+      m["updated"] = parseDate(element.value("updated_at").toString(), true);
+      m["body"] = element.value("body").toString();
+      rlist.append(m);
+    }
+
+    QVariantMap result = value->value();
+    result["discussion"] = rlist;
+
+    value->setValue(issue_id, result);
+    reply->deleteLater();
+  });
+}
+
+void ProjectForgejo::issue(const QString &issue_id, LoadableObject *value) {
+  if (value->ready() && value->valueId()==issue_id)
+    return; // value already corresponds to that issue
+  value->reset(issue_id);
+
+  QNetworkReply *reply = sendQuery( QStringLiteral("/repos/%1/issues/%2").arg(m_path).arg(issue_id));
+  connect(reply, &QNetworkReply::finished, this, [this, issue_id, reply, value](){
+    if (reply->error() != QNetworkReply::NoError) {
+      qWarning() << "Forgejo: Failed to fetch issue for" << this->m_path;
+      qWarning() << "Forgejo: Error: " << reply->errorString();
+    }
+
+    QByteArray data = reply->readAll();
+    QVariantMap r = QJsonDocument::fromJson(data).object().toVariantMap();
+
+    QVariantMap result;
+    result["id"] = r.value("number").toInt();
+    result["number"] = r.value("number");
+    result["title"] = r.value("title");
+    result["commentsCount"] = r.value("comments").toInt();
+
+    value->setValue(issue_id, result);
+
+    // load comments separately: save "first comment"
+    QVariantMap commentZero;
+    commentZero["author"] = getName(r.value("user"));
+    commentZero["created"] = parseDate(r.value("created_at").toString(), true);
+    commentZero["updated"] = parseDate(r.value("updated_at").toString(), true);
+    // FIXME: this is stored as markdown, not HTML
+    //        maybe use /miscellaneous/renderMarkdown to get HTML
+    commentZero["body"] = r.value("body").toString();
+
+    // load comments
+    comments(result["id"].toString(), commentZero, value);
+
+    reply->deleteLater();
+  });
+}
+
+void ProjectForgejo::issues(LoadableObject *value) {
+  const QString issues_id{QStringLiteral("issues")};
+  value->reset(issues_id);
+
+  QNetworkReply *reply = sendQuery( QStringLiteral("/repos/%1/%2?state=open&type=issue").arg(m_path).arg(issues_id));
+
+  connect(reply, &QNetworkReply::finished, this, [this, issues_id, reply, value](){
+    if (reply->error() != QNetworkReply::NoError) {
+      qWarning() << "Forgejo: Failed to fetch issues for" << this->m_path;
+      qWarning() << "Forgejo: Error: " << reply->errorString();
+    }
+
+    QByteArray data = reply->readAll();
+    QVariantList r = QJsonDocument::fromJson(data).array().toVariantList();
+
+    QVariantList rlist;
+    for (const auto &e: r) {
+      QVariantMap element = e.toMap();
+      QVariantMap m;
+      m["id"] = element.value("number");
+      m["author"] = getName(element.value("user"));
+      m["commentsCount"] = element.value("comments");
+      m["number"] = element.value("number");
+      m["title"] = element.value("title");
+      m["created"] = parseDate(element.value("created_at").toString(), true);
+      m["updated"] = parseDate(element.value("updated_at").toString(), true);
+      rlist.append(m);
+    }
+
+    QVariantMap result;
+    result["issues"] = rlist;
+    value->setValue(issues_id, result);
+
+    reply->deleteLater();
+  });
+}
+
+
+void ProjectForgejo::release(const QString &release_id, LoadableObject *value) {
+  if (value->ready() && value->valueId()==release_id)
+    return; // value already corresponds to that release
+  value->reset(release_id);
+
+  QNetworkReply *reply = sendQuery( QStringLiteral("/repos/%1/releases/%2").arg(m_path).arg(release_id));
+
+  connect(reply, &QNetworkReply::finished, this, [this, release_id, reply, value](){
+    if (reply->error() != QNetworkReply::NoError) {
+      qWarning() << "Forgejo: Failed to fetch release for" << this->m_path;
+      qWarning() << "Forgejo: Error: " << reply->errorString();
+    }
+
+    QByteArray data = reply->readAll();
+    QVariantMap r = QJsonDocument::fromJson(data).object().toVariantMap();
+
+    QVariantMap result;
+    result["name"] = r.value("name");
+    result["description"] = r.value("body");
+    result["datetime"] = parseDate(r.value("created_at").toString());
+
+    value->setValue(release_id, result);
+    reply->deleteLater();
+  });
+}
+
+
+void ProjectForgejo::releases(LoadableObject *value) {
+  const QString releases_id{QStringLiteral("releases")};
+  value->reset(releases_id);
+
+  QNetworkReply *reply = sendQuery( QStringLiteral("/repos/%1/%2?pre-release=true").arg(m_path).arg(releases_id));
+
+  connect(reply, &QNetworkReply::finished, this, [this, releases_id, reply, value](){
+    if (reply->error() != QNetworkReply::NoError) {
+      qWarning() << "Forgejo: Failed to fetch releases for" << this->m_path;
+      qWarning() << "Forgejo: Error: " << reply->errorString();
+    }
+
+    QByteArray data = reply->readAll();
+    QVariantList r = QJsonDocument::fromJson(data).array().toVariantList();
+
+    QVariantList rlist;
+    for (const auto &e: r) {
+      QVariantMap element = e.toMap();
+      QVariantMap m;
+      m["id"] = element.value("id");
+      m["name"] = element.value("name");
+      m["datetime"] = parseDate(element.value("created_at").toString());
+      rlist.append(m);
+    }
+
+    QVariantMap result;
+    result["releases"] = rlist;
+    value->setValue(releases_id, result);
+
+    reply->deleteLater();
+  });
+}

--- a/src/projectforgejo.h
+++ b/src/projectforgejo.h
@@ -1,0 +1,41 @@
+#ifndef PROJECTFORGEJO_H
+#define PROJECTFORGEJO_H
+
+#include <QObject>
+#include <QNetworkReply>
+#include <QString>
+#include <QVariantMap>
+
+#include "projectabstract.h"
+
+class ProjectForgejo : public ProjectAbstract
+{
+    Q_OBJECT
+public:
+    explicit ProjectForgejo(const QString &url, ChumPackage *package);
+
+    static bool isProject(const QString &url);
+
+    virtual void issue(const QString &id, LoadableObject *value) override;
+    virtual void issues(LoadableObject *value) override;
+    virtual void release(const QString &id, LoadableObject *value) override;
+    virtual void releases(LoadableObject *value) override;
+
+signals:
+
+private:
+    QNetworkReply* sendQuery(const QString &query);
+    void fetchRepoInfo();
+
+    static void initSites();
+
+    void comments(const QString &id, const QVariantMap &comment, LoadableObject *value);
+private:
+    QString m_host;
+    QString m_path;
+    QString m_token;
+
+    static QMap<QString, QString> s_sites;
+};
+
+#endif // PROJECTFORGEJO_H


### PR DESCRIPTION
This adds support for remote SCM hosts running gitea or forgejo software, similar to the gitlab and github integration we already have (except this is not using GraphQL).

Tested only with codeberg.org (forgejo), and by running curl against https://try.gitea.io.  

API docs can be accessed by browsing to `<instance host>/api/swagger` for both gitea and forgejo, e.g:

 - https://codeberg.org/api/swagger
 - https://try.gitea.io/api/swagger

A new API key will have to be generated for at least codeberg.org so Github can use it in the build Action.
The format of the `TOKEN_FORGEJO` for github actions follows that of the Gitlab implementation:

    "gitea.example.com:XXXX|forgejo.example.com:YYYY|...|siteN:tokenN"

Quoting being essential here! (The github workflow breaks otherwise because of pipes in a shell script!)

s.a. https://github.com/sailfishos-chum/sailfishos-chum-gui/pull/44
