### PR TITLE
Add support for new release URL macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ project(sailfishos-chum-gui
 set(GITHUB_TOKEN "unset" CACHE STRING "GitHub access token for GraphQL queries")
 set(GITLAB_TOKEN "unset" CACHE STRING "GitLab access site-token pair(s) for GraphQL queries")
 set(FORGEJO_TOKEN "unset" CACHE STRING "Forgejo (and Gitea) access site-token pair(s) for API queries")
+set(SAILFISHOS_TARGET_VERSION 0 CACHE STRING "Target Sailfish OS version")
 
 include(FindPkgConfig)
 

--- a/rpm/sailfishos-chum-gui.spec
+++ b/rpm/sailfishos-chum-gui.spec
@@ -1,7 +1,6 @@
 Name:           sailfishos-chum-gui
 Summary:        GUI application for utilising the SailfishOS:Chum community repository
-# The %%{version} tag must adhere to semantic versioning: Among multiple other
-# reasons due to its use for `qmake5` in line 94.  See https://semver.org/
+# The %%{version} tag must adhere to semantic versioning.  See https://semver.org/
 Version:        0.6.7
 Release:        2
 # The Group tag should comprise one of the groups listed here:
@@ -42,7 +41,7 @@ BuildRequires:  sailfish-svg2png
 BuildRequires:  qt5-qttools-linguist
 BuildRequires:  sed
 
-# Bundle YAML-C++ library (for OBS builds) only for older SFOS version targets < v4.0.0.00
+# Bundle YAML-C++ library (for OBS builds) only for older SFOS version targets < v4.0.0
 %if %{defined sailfishos_version} && 0%{?sailfishos_version} < 40000
 %define bundle_yaml 1
 %endif
@@ -92,7 +91,7 @@ Links:
 
 %build
 # SFOS RPM cmake macro disables RPATH
-%cmake -DCHUMGUI_VERSION=%(echo %{version} | grep -Eo '^[0-9]+(\.[0-9]+)*')  \
+%cmake -DCHUMGUI_VERSION=%(echo %{version} | grep -Eo '^[0-9]+\.[0-9]+\.[0-9]+')  \
        -DSAILFISHOS_TARGET_VERSION=%{!?sailfishos_version:0}%{?sailfishos_version} \
        -DCMAKE_SKIP_RPATH:BOOL=OFF  \
        -DCMAKE_INSTALL_RPATH=%{_datadir}/%{name}/lib:  \
@@ -115,7 +114,7 @@ cp -a %{_libdir}/libyaml-cpp.so.* %{buildroot}%{_datadir}/%{name}/lib
 chmod -x %{buildroot}%{_datadir}/%{name}/lib/*.so*
 %endif
 
-# Rectify desktop file for older SFOS version targets < v4.0.1.00
+# Rectify desktop file for older SFOS version targets < v4.1.0
 %if %{defined sailfishos_version} && 0%{?sailfishos_version} < 40100
 sed -i 's/silica-qt5/generic/' %{buildroot}%{_datadir}/applications/sailfishos-chum-gui.desktop
 %endif

--- a/rpm/sailfishos-chum-gui.spec
+++ b/rpm/sailfishos-chum-gui.spec
@@ -93,6 +93,7 @@ Links:
 %build
 # SFOS RPM cmake macro disables RPATH
 %cmake -DCHUMGUI_VERSION=%(echo %{version} | grep -Eo '^[0-9]+(\.[0-9]+)*')  \
+       -DSAILFISHOS_TARGET_VERSION=0%{?sailfishos_version} \
        -DCMAKE_SKIP_RPATH:BOOL=OFF  \
        -DCMAKE_INSTALL_RPATH=%{_datadir}/%{name}/lib:  \
        -DGITHUB_TOKEN=%(cat %{SOURCE1})  \

--- a/rpm/sailfishos-chum-gui.spec
+++ b/rpm/sailfishos-chum-gui.spec
@@ -92,7 +92,7 @@ Links:
 
 %build
 # SFOS RPM cmake macro disables RPATH
-%cmake -DCHUMGUI_VERSION=%{version}  \
+%cmake -DCHUMGUI_VERSION=%(echo %{version} | grep -Eo '^[0-9]+(\.[0-9]+)*')  \
        -DCMAKE_SKIP_RPATH:BOOL=OFF  \
        -DCMAKE_INSTALL_RPATH=%{_datadir}/%{name}/lib:  \
        -DGITHUB_TOKEN=%(cat %{SOURCE1})  \

--- a/rpm/sailfishos-chum-gui.spec
+++ b/rpm/sailfishos-chum-gui.spec
@@ -93,7 +93,7 @@ Links:
 %build
 # SFOS RPM cmake macro disables RPATH
 %cmake -DCHUMGUI_VERSION=%(echo %{version} | grep -Eo '^[0-9]+(\.[0-9]+)*')  \
-       -DSAILFISHOS_TARGET_VERSION=0%{?sailfishos_version} \
+       -DSAILFISHOS_TARGET_VERSION=%{!?sailfishos_version:0}%{?sailfishos_version} \
        -DCMAKE_SKIP_RPATH:BOOL=OFF  \
        -DCMAKE_INSTALL_RPATH=%{_datadir}/%{name}/lib:  \
        -DGITHUB_TOKEN=%(cat %{SOURCE1})  \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,6 +46,10 @@ set_source_files_properties(projectforgejo.cpp PROPERTIES
   COMPILE_DEFINITIONS FORGEJO_TOKEN=\"${FORGEJO_TOKEN}\"
 )
 
+set_source_files_properties(ssu.cpp PROPERTIES
+  COMPILE_DEFINITIONS SAILFISHOS_TARGET_VERSION=${SAILFISHOS_TARGET_VERSION}
+)
+
 target_link_libraries(${PROJECT_NAME}
   Qt5::Quick
   Qt5::DBus

--- a/src/ssu.cpp
+++ b/src/ssu.cpp
@@ -4,14 +4,20 @@
 #include <QDBusPendingReply>
 #include <QDebug>
 
+#if defined(sailfishos_version) && sailfishos_version >= 40600
+#define RELEASE_TAG "%(releaseMajorMinor)"
+#else
+#define RELEASE_TAG "%(release)"
+#endif
+
 static QString s_repo_regular(
-        QStringLiteral("https://repo.sailfishos.org/obs/sailfishos:/chum/%(release)_%(arch)/"));
+        QStringLiteral("https://repo.sailfishos.org/obs/sailfishos:/chum/" RELEASE_TAG "_%(arch)/"));
 static QString s_repo_regular_alias(
         QStringLiteral("sailfishos-chum"));
 static QString s_repo_regular_prefix(
         QStringLiteral("https://repo.sailfishos.org/obs/sailfishos:/chum/"));
 static QString s_repo_testing(
-        QStringLiteral("https://repo.sailfishos.org/obs/sailfishos:/chum:/testing/%(release)_%(arch)/"));
+        QStringLiteral("https://repo.sailfishos.org/obs/sailfishos:/chum:/testing/" RELEASE_TAG "_%(arch)/"));
 static QString s_repo_testing_alias(
         QStringLiteral("sailfishos-chum-testing"));
 static QString s_repo_testing_prefix(
@@ -131,7 +137,7 @@ void Ssu::setRepo(const QString &version, bool testing) {
     QString url = testing ? s_repo_testing : s_repo_regular;
 
     if (!version.isEmpty()) {
-        url = url.replace(QLatin1String("%(release)"), version);
+        url = url.replace(QLatin1String(RELEASE_TAG), version);
     }
 
     if (rname != m_repo_name) {

--- a/src/ssu.cpp
+++ b/src/ssu.cpp
@@ -4,7 +4,7 @@
 #include <QDBusPendingReply>
 #include <QDebug>
 
-#if defined(sailfishos_version) && sailfishos_version >= 40600
+#if defined(SAILFISHOS_TARGET_VERSION) && SAILFISHOS_TARGET_VERSION >= 40600
 #define RELEASE_TAG "%(releaseMajorMinor)"
 #else
 #define RELEASE_TAG "%(release)"


### PR DESCRIPTION
- Switches to new URL macro in SFOS >= 4.6. In longer term, allows to reduce the load on OBS and its administration

- Reenable processing of the version string before adding it as CMake option. Without it, test builds will fail at OBS

Test build available at https://build.sailfishos.org/package/show/home:rinigus:tmp/sailfishos-chum-gui

Please check on SFOS 4.6.x.x as I don't have access to it. For that, use GUI build from 4.6 repo

Fixes: #270 