### PR TITLE
[ci-on-tags.yml] Reverse martix order, because …

### DIFF
--- a/.github/workflows/ci-on-tags.yml
+++ b/.github/workflows/ci-on-tags.yml
@@ -32,7 +32,7 @@ jobs:
         # For available docker images, see https://github.com/CODeRUS/docker-sailfishos-platform-sdk#readme
         # Use the oldest Docker SFOS-Platform-SDK image, which produces binaries which are still compatible
         # with the current SailfishOS release, and the oldest image on which working binaries are generated.
-        release: [4.6.0.13, 4.3.0.12, 4.1.0.24]
+        release: [4.1.0.24, 4.3.0.12, 4.6.0.13]
         # Cannot use two matrix dimensions, because the ARCH-specific builds must be
         # carried out in a single job to allow for reuse of the downloaded Docker image.
     env:


### PR DESCRIPTION
… the idea is to fail early with an SDK image, which is much smaller to download than the recent ones.